### PR TITLE
add test for PDT vs PST

### DIFF
--- a/lcls_tools/data_analysis/archiver.py
+++ b/lcls_tools/data_analysis/archiver.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta
 from typing import Dict, List, Union
 from unittest import TestCase, main as test
+import time
 
 import requests
 
@@ -14,7 +15,12 @@ except ImportError:
 
 # The double braces are to allow for partial formatting
 ARCHIVER_URL_FORMATTER = "http://{MACHINE}-archapp.slac.stanford.edu/retrieval/data/{{SUFFIX}}"
-SINGLE_RESULT_SUFFIX = "getDataAtTime?at={TIME}-07:00&includeProxies=true"
+# If daylight savings time, SLAC is 7 hours behind UTC otherwise 8
+if time.localtime().tm_isdst:
+  utcDeltaT="-07:00"
+else:
+  utcDeltaT="-08:00"
+SINGLE_RESULT_SUFFIX = "getDataAtTime?at={TIME}"+utcDeltaT+"&includeProxies=true"
 RANGE_RESULT_SUFFIX = "getData.json"
 
 TIMEOUT = 3

--- a/lcls_tools/data_analysis/archiver.py
+++ b/lcls_tools/data_analysis/archiver.py
@@ -17,10 +17,10 @@ except ImportError:
 ARCHIVER_URL_FORMATTER = "http://{MACHINE}-archapp.slac.stanford.edu/retrieval/data/{{SUFFIX}}"
 # If daylight savings time, SLAC is 7 hours behind UTC otherwise 8
 if time.localtime().tm_isdst:
-  utcDeltaT="-07:00"
+  UTC_DELTA_T="-07:00"
 else:
-  utcDeltaT="-08:00"
-SINGLE_RESULT_SUFFIX = "getDataAtTime?at={TIME}"+utcDeltaT+"&includeProxies=true"
+  UTC_DELTA_T="-08:00"
+SINGLE_RESULT_SUFFIX = "getDataAtTime?at={TIME}"+UTC_DELTA_T+"&includeProxies=true"
 RANGE_RESULT_SUFFIX = "getData.json"
 
 TIMEOUT = 3
@@ -102,11 +102,10 @@ class Archiver:
                 times[pv] = []
                 values[pv] = []
 
-                # Need to add the -7 because pacific time is UTC-7!
                 response = requests.get(url=url, timeout=TIMEOUT,
                                         params={"pv"  : pv,
-                                                "from": startTime.isoformat() + "-07:00",
-                                                "to"  : endTime.isoformat() + "-07:00"})
+                                                "from": startTime.isoformat() + UTC_DELTA_T,
+                                                "to"  : endTime.isoformat() + UTC_DELTA_T})
 
                 try:
                     jsonData = json.loads(response.text)


### PR DESCRIPTION
Hi!

in archiver.py in data_analysis, the 7 hour offset from PDT to UTC was hardcoded. I added a test for DST then used 7 or 8 hours as needed.