### PR TITLE
fixing typo

### DIFF
--- a/lcls_tools/common/pyepics_tools/pyepicsUtils.py
+++ b/lcls_tools/common/pyepics_tools/pyepicsUtils.py
@@ -41,7 +41,7 @@ class PV(epics_pv):
 
     def get(self, count=None, as_string=False, as_numpy=True,
             timeout=None, with_ctrlvars=False, use_monitor=True,
-            use_caget=False):
+            use_caget=True):
 
         if use_caget:
             self.caget()
@@ -59,7 +59,7 @@ class PV(epics_pv):
 
     def put(self, value, wait=True, timeout=30.0,
             use_complete=False, callback=None, callback_data=None, retry=True,
-            use_caput=False):
+            use_caput=True):
 
         if use_caput:
             return self.caput(value)

--- a/lcls_tools/common/pyepics_tools/pyepicsUtils.py
+++ b/lcls_tools/common/pyepics_tools/pyepicsUtils.py
@@ -17,10 +17,10 @@ class PVInvalidError(Exception):
 class PV(epics_pv):
     def __init__(self, pvname):
         super().__init__(pvname, connection_timeout=0.01)
-    
+
     def __str__(self):
         return f"{self.pvname} PV Object"
-    
+
     def caget(self):
         while True:
             value = epics_caget(self.pvname)
@@ -29,7 +29,7 @@ class PV(epics_pv):
             print(f"{self.pvname} did not return a valid value, retrying")
             sleep(0.5)
         return value
-    
+
     def caput(self, value):
         while True:
             status = epics_caput(self.pvname, value)
@@ -38,36 +38,36 @@ class PV(epics_pv):
             print(f"{self} caput did not execute successfully, retrying")
             sleep(0.5)
         return status
-    
+
     def get(self, count=None, as_string=False, as_numpy=True,
             timeout=None, with_ctrlvars=False, use_monitor=True,
             use_caget=False):
-        
+
         if use_caget:
             self.caget()
-        
+
         else:
             self.connect()
-            
+
             value = super().get(count, as_string, as_numpy, timeout,
                                 with_ctrlvars, use_monitor)
             if value is not None:
                 return value
             else:
-                print(f"{self} put failed, trying caget instead")
+                print(f"{self} get failed, trying caget instead")
                 return self.caget()
-    
+
     def put(self, value, wait=True, timeout=30.0,
             use_complete=False, callback=None, callback_data=None, retry=True,
             use_caput=False):
-        
+
         if use_caput:
             return self.caput(value)
-        
+
         status = super().put(value, wait=wait, timeout=timeout,
                              use_complete=use_complete, callback=callback,
                              callback_data=callback_data)
-        
+
         if retry and (status is not 1):
             print(f"{self} put not successful, using caput")
             self.caput(value)


### PR DESCRIPTION
fixing confusing typo in the error message when the PV object get fails (said 'put' instead of 'get')