### PR TITLE
adding too and refactoring screen class

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,22 @@
+# conda env create -f environment.yml
+name: lcls-tools
+channels:
+  - conda-forge
+dependencies:
+  - python>=3.9
+  - numpy
+  - setuptools
+  - scipy
+  - matplotlib
+  - pyepics
+  - pydantic>=2.3
+  - pyyaml
+  - requests
+  - h5py
+  - scikit-learn
+# documentation
+  - sphinx
+  - sphinx_rtd_theme
+  - myst-parser
+#  - pip:
+#    - git+git://github.com/some/repo

--- a/lcls_tools/common/devices/screen.py
+++ b/lcls_tools/common/devices/screen.py
@@ -1,33 +1,28 @@
-import datetime
+import os
 import os
 import time
 from abc import ABC, abstractmethod
 from copy import copy
 from typing import (
-    Any,
     Dict,
     Optional, Union, List,
 )
-from threading import Thread
 
-from matplotlib import pyplot as plt, patches
+import numpy as np
+from epics import PV
+from matplotlib import patches
+from pydantic import (
+    BaseModel,
+    SerializeAsAny,
+    field_validator, FilePath, PositiveFloat,
+)
 
-from lcls_tools.common.data_analysis.fitting_tool import FittingTool
 from lcls_tools.common.devices.device import (
     Device,
     ControlInformation,
     Metadata,
     PVSet,
 )
-
-from epics import PV
-import h5py
-from pydantic import (
-    BaseModel,
-    SerializeAsAny,
-    field_validator, FilePath, DirectoryPath, PositiveFloat,
-)
-import numpy as np
 
 
 class ScreenPVSet(PVSet):
@@ -151,23 +146,13 @@ class ScreenControlInformation(ControlInformation):
 class Screen(Device):
     controls_information: SerializeAsAny[ScreenControlInformation]
     metadata: SerializeAsAny[Metadata]
-    saving_images: bool = False
-    save_location: Union[DirectoryPath, None] = None
     background_file: Optional[FilePath] = None
-    wait_time: PositiveFloat = 1.0
-
     roi: Optional[ROI] = None
-    fitting_tool: Optional[FittingTool] = None
+    timeout_in_seconds: PositiveFloat = 10.0
 
-    _last_save_filepath: Optional[str] = ""
-
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
-
-    @property
-    def raw_image(self) -> np.ndarray:
+    def get_raw_image(self) -> np.ndarray:
         """
-        The current image from EPICS
+        Get the current image from EPICS
         reshaped to the dimensions of
         the camera associated with this screen
         """
@@ -175,152 +160,19 @@ class Screen(Device):
             self.n_rows, self.n_columns
         )
 
-    @property
-    def processed_image(self) -> np.ndarray:
-        img = self.raw_image
-        # subtract background
-        img = img - self.background_image
-        img = np.where(img >= 0, img, 0)
+    def get_processed_image(self) -> np.ndarray:
+        """ get a processed image from EPICS"""
+        img = self.get_raw_image()
+
+        # subtract background if available
+        if self.background_image is not None:
+            img = img - self.background_image
+            img = np.where(img >= 0, img, 0)
 
         # crop image if specified
         if self.roi is not None:
             img = self.roi.crop_image(img)
         return img
-
-    def measure_images(
-            self,
-            num_to_capture: int = 1,
-            extra_metadata: Optional[Dict[str, Any]] = None,
-            threaded=False,
-            timeout_in_seconds: int = 10,
-            fit_images: bool = True
-    ):
-        """
-        Collect and saves images to HDF5.
-        Option for threading which spawns a child process
-        in a way that dependant GUIs/Code do not hang.
-        The extra_metadata dictionary will be attached
-        to the metadata for each image in HDF5 .
-
-        """
-        if threaded:
-            work = Thread(
-                target=self._take_images,
-                args=[
-                    num_to_capture,
-                    extra_metadata,
-                    timeout_in_seconds,
-                ],
-            )
-            # normally we join after start, but that blocked the pyqt main thread
-            # so we do not join here. If it breaks, look here first..
-            work.start()
-        else:
-            images = self._take_images(
-                num_collect=num_to_capture,
-                extra_metadata=extra_metadata,
-                timeout=timeout_in_seconds,
-            )
-
-            if fit_images:
-                if self.fitting_tool is not None:
-                    image_stats = self.fitting_tool.fit_images(images)
-
-                else:
-                    raise RuntimeError("fitting tool required to fit images")
-
-                result = image_stats | self.metadata
-                result = result | extra_metadata
-
-                return images, result
-
-            else:
-                return images, {}
-
-    def test_measurement(
-            self,
-            timeout_in_seconds: int = 10,
-            fit_images: bool = True
-    ):
-
-        image, result = self.measure_images(
-            fit_images=fit_images, timeout_in_seconds=timeout_in_seconds
-        )
-
-        # visualize result
-        fig, ax = plt.subplots()
-        c = ax.imshow(image, origin="lower")
-        fig.colorbar(c)
-
-        # visualize beam bounding box, ROI, etc.
-        beam_bounding_box = self.fitting_tool.get_beam_bounding_box()
-        beam_centroid = [result["Cx"], result["Cy"]]
-        ax.plot(*beam_centroid, "+r")
-        ax.plot(*self.roi.center, ".r")
-        rect = patches.Rectangle(
-            *beam_bounding_box, facecolor="none", edgecolor="r"
-        )
-        ax.add_patch(rect)
-        roi_patch = self.roi.get_patch()
-        ax.add_patch(roi_patch)
-
-    def _take_images(
-            self,
-            num_collect: int = 1,
-            extra_metadata: Optional[Dict[str, Any]] = None,
-            timeout: int = 10,
-    ):
-        """
-        Performs the work for collecting images.
-        This procedure will collect all images and then save them all to file if
-        specified by the `save_images` attribute.
-
-        If, for any image, we cannot collect within the time provided as timeout,
-        we will stop collecting and save out what was collected before the failure.
-        """
-
-        captures = []
-        last_updated_at = self.image_timestamp
-        acquisition_start = datetime.datetime.now()
-        while len(captures) != num_collect:
-            # check timeout condition
-            if datetime.datetime.now() - acquisition_start > datetime.timedelta(
-                    seconds=timeout
-            ):
-                print(
-                    "Could not save capture ",
-                    len(captures) + 1,
-                    " out of ",
-                    num_collect,
-                    " due to timeout. Exiting image collection for ",
-                    self.name,
-                    ". Saving out to HDF5 will happen now.",
-                )
-                break
-
-            if self.image_timestamp != last_updated_at:
-                capture = self.image
-                last_updated_at = self.image_timestamp
-                captures.append(capture)
-
-                # if we are collecting multiple images wait some amount of time
-                if num_collect > 1:
-                    time.sleep(self.wait_time)
-
-                acquisition_start = datetime.datetime.now()
-
-        # collect list of images into a np array
-        captures = np.array(captures)
-        if self.save_images:
-            filename = self._generate_new_filename()
-            self._write_images_to_hdf5(
-                images=captures,
-                filename=filename,
-                extra_metadata=extra_metadata,
-            )
-            self._last_save_filepath = filename
-
-        return captures
 
     def measure_background(self, n_measurements: int = 5, file_location: str = None):
         loc = copy(self.save_image_location)
@@ -332,7 +184,10 @@ class Screen(Device):
         self.shutter_beam()
         time.sleep(1.0)
 
-        images = self._take_images(n_measurements)
+        images = []
+        for i in range(n_measurements):
+            images += [self.get_processed_image()]
+            time.sleep(self.wait_time_in_seconds)
 
         # restore shutter state
         if old_shutter_state:
@@ -348,6 +203,13 @@ class Screen(Device):
         self.background_file = filename
 
         return mean
+
+    @property
+    def background_image(self) -> Union[np.ndarray, None]:
+        if self.background_file is not None:
+            return np.load(self.background_file)
+        else:
+            return None
 
     @property
     def image_timestamp(self):
@@ -394,50 +256,6 @@ class Screen(Device):
     def _inserted_check(self):
         """Check if the screen is inserted"""
         return NotImplementedError
-
-
-    def _generate_new_filename(self, extension: Optional[str] = ".h5") -> str:
-        """
-        Make a new filename for the HDF5 image file
-        Should be of the form: <save-location>/<timestamp>_<screen_name>.h5
-        """
-        stamp = datetime.datetime.now().isoformat()
-        stamp_str = stamp.replace(".", "_").replace("-", "_").replace(":", "_")
-        filename = stamp_str + "_" + self.name + extension
-        path = str(os.path.join(self._root_hdf5_location, filename))
-        return path
-
-    def _write_images_to_hdf5(
-            self,
-            images: np.ndarray,
-            filename: str,
-            extra_metadata: Optional[Dict[str, Any]] = None,
-    ):
-        """
-        Saves a set of images to the hdf_save_location with the filename provided.
-        Any metadata provided as extra_metadata will be attached to each dataset in the HDF5 file.
-        """
-        with h5py.File(filename, "a") as f:
-            capture_num = 0
-            for image in images:
-                # todo, check type-representation of images, are we sure they are unsigned-shorts??
-                dset = f.create_dataset(
-                    name=str(capture_num), data=image, dtype=np.ushort
-                )
-                [dset.attrs.update({key: value}) for key, value in self.metadata]
-                if extra_metadata:
-                    # dset.attrs acts as a dictionary here
-                    # we update with original key if it isn't in our normal screen metadata
-                    # otherwise, prepend user_ to the key to retain all information.
-                    [
-                        dset.attrs.update({key: value})
-                        if key not in self.metadata
-                        else dset.attrs.update({"user_" + key: value})
-                        for key, value in extra_metadata.items()
-                    ]
-
-                capture_num += 1
-        return
 
 
 class ScreenCollection(BaseModel):

--- a/lcls_tools/common/devices/screen.py
+++ b/lcls_tools/common/devices/screen.py
@@ -1,12 +1,18 @@
 import datetime
 import os
+import time
+from abc import ABC, abstractmethod
+from copy import copy
 from typing import (
     Any,
     Dict,
-    Optional,
+    Optional, Union, List,
 )
 from threading import Thread
 
+from matplotlib import pyplot as plt, patches
+
+from lcls_tools.common.data_analysis.fitting_tool import FittingTool
 from lcls_tools.common.devices.device import (
     Device,
     ControlInformation,
@@ -19,7 +25,7 @@ import h5py
 from pydantic import (
     BaseModel,
     SerializeAsAny,
-    field_validator,
+    field_validator, FilePath, DirectoryPath, PositiveFloat,
 )
 import numpy as np
 
@@ -37,6 +43,7 @@ class ScreenPVSet(PVSet):
     n_row: PV
     n_bits: PV
     resolution: PV
+    shutter: PV
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
@@ -45,6 +52,93 @@ class ScreenPVSet(PVSet):
     def validate_pv_fields(cls, v: str):
         """Convert each PV string from YAML into a PV object"""
         return PV(v)
+
+
+class ROI(BaseModel, ABC):
+    roi_type: str
+    center: List[PositiveFloat]
+
+    @abstractmethod
+    def crop_image(self, img, **kwargs) -> np.ndarray:
+        """ crop image using ROI"""
+        pass
+
+    @abstractmethod
+    def get_patch(self):
+        pass
+
+
+class CircularROI(ROI):
+    """
+    Define a circular region of interest (ROI) for an image, cropping pixels outside a
+    bounding box around the ROI and setting pixels outside the boundary to a fill
+    value (usually zero).
+    """
+    roi_type = "circular"
+    radius: PositiveFloat
+
+    @property
+    def bounding_box(self):
+        return [self.center[0] - int(self.radius),
+                self.center[1] - int(self.radius),
+                self.radius * 2, self.radius * 2]
+
+    def crop_image(self, img, **kwargs) -> np.ndarray:
+        x_size, y_size = img.shape
+        fill_value = kwargs.get("fill_value", 0.0)
+
+        if self.xwidth > x_size or self.ywidth > y_size:
+            raise ValueError(
+                f"must specify ROI that is smaller than the image, "
+                f"image size is {img.shape}"
+            )
+
+        bbox = self.bounding_box
+        img = img[..., bbox[0]: bbox[0] + bbox[2], bbox[1]: bbox[1] + bbox[3]]
+
+        # TODO: fill px values outside region with fill value
+
+        return img
+
+    def get_patch(self):
+        return patches.Circle(
+            tuple(self.center), self.radius, facecolor="none", edgecolor="r"
+        )
+
+
+class RectangularROI(BaseModel):
+    """
+    Define a circular region of interest (ROI) for an image, cropping pixels outside
+    the ROI.
+    """
+
+    xwidth: int
+    ywidth: int
+
+    @property
+    def bounding_box(self):
+        return [self.center[0] - int(self.xwidth / 2),
+                self.center[1] - int(self.ywidth / 2),
+                self.xwidth, self.ywidth]
+
+    def crop_image(self, img, **kwargs) -> np.ndarray:
+        x_size, y_size = img.shape
+
+        if self.xwidth > x_size or self.ywidth > y_size:
+            raise ValueError(
+                f"must specify ROI that is smaller than the image, "
+                f"image size is {img.shape}"
+            )
+
+        bbox = self.bounding_box
+        img = img[bbox[0]: bbox[0] + bbox[2], bbox[1]: bbox[1] + bbox[3]]
+
+        return img
+
+    def get_patch(self):
+        return patches.Rectangle(
+            *self.bounding_box, facecolor="none", edgecolor="r"
+        )
 
 
 class ScreenControlInformation(ControlInformation):
@@ -57,15 +151,21 @@ class ScreenControlInformation(ControlInformation):
 class Screen(Device):
     controls_information: SerializeAsAny[ScreenControlInformation]
     metadata: SerializeAsAny[Metadata]
-    _saving_images: Optional[bool] = False
-    _root_hdf5_location: Optional[str] = "."
+    saving_images: bool = False
+    save_location: Union[DirectoryPath, None] = None
+    background_file: Optional[FilePath] = None
+    wait_time: PositiveFloat = 1.0
+
+    roi: Optional[ROI] = None
+    fitting_tool: Optional[FittingTool] = None
+
     _last_save_filepath: Optional[str] = ""
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
 
     @property
-    def image(self) -> np.ndarray:
+    def raw_image(self) -> np.ndarray:
         """
         The current image from EPICS
         reshaped to the dimensions of
@@ -76,27 +176,183 @@ class Screen(Device):
         )
 
     @property
+    def processed_image(self) -> np.ndarray:
+        img = self.raw_image
+        # subtract background
+        img = img - self.background_image
+        img = np.where(img >= 0, img, 0)
+
+        # crop image if specified
+        if self.roi is not None:
+            img = self.roi.crop_image(img)
+        return img
+
+    def measure_images(
+            self,
+            num_to_capture: int = 1,
+            extra_metadata: Optional[Dict[str, Any]] = None,
+            threaded=False,
+            timeout_in_seconds: int = 10,
+            fit_images: bool = True
+    ):
+        """
+        Collect and saves images to HDF5.
+        Option for threading which spawns a child process
+        in a way that dependant GUIs/Code do not hang.
+        The extra_metadata dictionary will be attached
+        to the metadata for each image in HDF5 .
+
+        """
+        if threaded:
+            work = Thread(
+                target=self._take_images,
+                args=[
+                    num_to_capture,
+                    extra_metadata,
+                    timeout_in_seconds,
+                ],
+            )
+            # normally we join after start, but that blocked the pyqt main thread
+            # so we do not join here. If it breaks, look here first..
+            work.start()
+        else:
+            images = self._take_images(
+                num_collect=num_to_capture,
+                extra_metadata=extra_metadata,
+                timeout=timeout_in_seconds,
+            )
+
+            if fit_images:
+                if self.fitting_tool is not None:
+                    image_stats = self.fitting_tool.fit_images(images)
+
+                else:
+                    raise RuntimeError("fitting tool required to fit images")
+
+                result = image_stats | self.metadata
+                result = result | extra_metadata
+
+                return images, result
+
+            else:
+                return images, {}
+
+    def test_measurement(
+            self,
+            timeout_in_seconds: int = 10,
+            fit_images: bool = True
+    ):
+
+        image, result = self.measure_images(
+            fit_images=fit_images, timeout_in_seconds=timeout_in_seconds
+        )
+
+        # visualize result
+        fig, ax = plt.subplots()
+        c = ax.imshow(image, origin="lower")
+        fig.colorbar(c)
+
+        # visualize beam bounding box, ROI, etc.
+        beam_bounding_box = self.fitting_tool.get_beam_bounding_box()
+        beam_centroid = [result["Cx"], result["Cy"]]
+        ax.plot(*beam_centroid, "+r")
+        ax.plot(*self.roi.center, ".r")
+        rect = patches.Rectangle(
+            *beam_bounding_box, facecolor="none", edgecolor="r"
+        )
+        ax.add_patch(rect)
+        roi_patch = self.roi.get_patch()
+        ax.add_patch(roi_patch)
+
+    def _take_images(
+            self,
+            num_collect: int = 1,
+            extra_metadata: Optional[Dict[str, Any]] = None,
+            timeout: int = 10,
+    ):
+        """
+        Performs the work for collecting images.
+        This procedure will collect all images and then save them all to file if
+        specified by the `save_images` attribute.
+
+        If, for any image, we cannot collect within the time provided as timeout,
+        we will stop collecting and save out what was collected before the failure.
+        """
+
+        captures = []
+        last_updated_at = self.image_timestamp
+        acquisition_start = datetime.datetime.now()
+        while len(captures) != num_collect:
+            # check timeout condition
+            if datetime.datetime.now() - acquisition_start > datetime.timedelta(
+                    seconds=timeout
+            ):
+                print(
+                    "Could not save capture ",
+                    len(captures) + 1,
+                    " out of ",
+                    num_collect,
+                    " due to timeout. Exiting image collection for ",
+                    self.name,
+                    ". Saving out to HDF5 will happen now.",
+                )
+                break
+
+            if self.image_timestamp != last_updated_at:
+                capture = self.image
+                last_updated_at = self.image_timestamp
+                captures.append(capture)
+
+                # if we are collecting multiple images wait some amount of time
+                if num_collect > 1:
+                    time.sleep(self.wait_time)
+
+                acquisition_start = datetime.datetime.now()
+
+        # collect list of images into a np array
+        captures = np.array(captures)
+        if self.save_images:
+            filename = self._generate_new_filename()
+            self._write_images_to_hdf5(
+                images=captures,
+                filename=filename,
+                extra_metadata=extra_metadata,
+            )
+            self._last_save_filepath = filename
+
+        return captures
+
+    def measure_background(self, n_measurements: int = 5, file_location: str = None):
+        loc = copy(self.save_image_location)
+        file_location = file_location or loc
+
+        filename = os.path.join(file_location, f"{self.name}_background.npy")
+        # insert shutter
+        old_shutter_state = copy(self.beam_shuttered)
+        self.shutter_beam()
+        time.sleep(1.0)
+
+        images = self._take_images(n_measurements)
+
+        # restore shutter state
+        if old_shutter_state:
+            self.shutter_beam()
+        else:
+            self.unshutter_beam()
+
+        # return average
+        images = np.stack(images)
+        mean = images.mean(axis=0)
+
+        np.save(filename, mean)
+        self.background_file = filename
+
+        return mean
+
+    @property
     def image_timestamp(self):
         """Get last timestamp for last PV activity"""
         return self.controls_information.PVs.image.timestamp
-
-    @property
-    def hdf_save_location(self) -> str:
-        """The location where any HDF5 file for images is saved for this screen"""
-        return self._root_hdf5_location
-
-    @hdf_save_location.setter
-    def hdf_save_location(self, path: str):
-        """Set the save location of any HDF5 files for images of this screen"""
-        if not os.path.isdir(path):
-            raise AttributeError(
-                f"Could not set {self.name} HDF5 save location. Please provide an existing directory."
-            )
-        self._root_hdf5_location = path
-
-    @property
-    def is_saving_images(self):
-        return self._saving_images
 
     @property
     def n_columns(self):
@@ -120,12 +376,25 @@ class Screen(Device):
 
     @property
     def last_save_filepath(self):
-        """Location and filename for the last file saved by this screen (set in save_images())"""
+        """Location and filename for the last file saved by this screen (set in
+        save_images())"""
         return self._last_save_filepath
 
-    def _inserted_check():
+    @property
+    def beam_shuttered(self) -> bool:
+        """ returns True if the laser/beam is shuttered"""
+        return not self.controls_information.PVs.shutter.get()
+
+    def shutter_beam(self):
+        self.controls_information.PVs.shutter.put(0)
+
+    def unshutter_beam(self):
+        self.controls_information.PVs.shutter.put(1)
+
+    def _inserted_check(self):
         """Check if the screen is inserted"""
         return NotImplementedError
+
 
     def _generate_new_filename(self, extension: Optional[str] = ".h5") -> str:
         """
@@ -138,92 +407,11 @@ class Screen(Device):
         path = str(os.path.join(self._root_hdf5_location, filename))
         return path
 
-    def save_images(
-        self,
-        num_to_capture: int = 1,
-        extra_metadata: Optional[Dict[str, Any]] = None,
-        threaded=True,
-        timeout_in_seconds: int = 10,
-    ):
-        """
-        Collect and saves images to HDF5.
-        Option for threading which spawns a child process
-        in a way that dependant GUIs/Code do not hang.
-        The extra_metadata dictionary will be attached
-        to the metadata for each image in HDF5 .
-
-        """
-        if threaded:
-            work = Thread(
-                target=self._take_images,
-                args=[
-                    num_to_capture,
-                    extra_metadata,
-                    timeout_in_seconds,
-                ],
-            )
-            # normally we join after start, but that blocked the pyqt main thread
-            # so we do not join here. If it breaks, look here first..
-            work.start()
-        else:
-            self._take_images(
-                num_collect=num_to_capture,
-                extra_metadata=extra_metadata,
-                timeout=timeout_in_seconds,
-            )
-
-    def _take_images(
-        self,
-        num_collect: int = 1,
-        extra_metadata: Optional[Dict[str, Any]] = None,
-        timeout: Optional[int] = 10,
-    ):
-        """
-        Performs the work for collecting images and saving to HDF5 file.
-        This procedure will collect all images and then save them all to file.
-
-        If, for any image, we cannot collect within the time provided as timeout,
-        we will stop collecting and save out what was collected before the failure.
-        """
-        self._saving_images = True
-        filename = self._generate_new_filename()
-        captures = []
-        last_updated_at = self.image_timestamp
-        acquisition_start = datetime.datetime.now()
-        while len(captures) != num_collect:
-            if datetime.datetime.now() - acquisition_start > datetime.timedelta(
-                seconds=timeout
-            ):
-                print(
-                    "Could not save capture ",
-                    len(captures) + 1,
-                    " out of ",
-                    num_collect,
-                    " due to timeout. Exiting image collection for ",
-                    self.name,
-                    ". Saving out to HDF5 will happen now.",
-                )
-                break
-            if self.image_timestamp != last_updated_at:
-                capture = self.image
-                last_updated_at = self.image_timestamp
-                captures.append(capture)
-                acquisition_start = datetime.datetime.now()
-        self._write_image_to_hdf5(
-            images=captures,
-            filename=filename,
-            extra_metadata=extra_metadata,
-        )
-        self._last_save_filepath = filename
-        self._saving_images = False
-        print("save images finished.")
-        return
-
-    def _write_image_to_hdf5(
-        self,
-        images: np.ndarray,
-        filename: str,
-        extra_metadata: Optional[Dict[str, Any]] = None,
+    def _write_images_to_hdf5(
+            self,
+            images: np.ndarray,
+            filename: str,
+            extra_metadata: Optional[Dict[str, Any]] = None,
     ):
         """
         Saves a set of images to the hdf_save_location with the filename provided.

--- a/lcls_tools/common/measurements/profile.py
+++ b/lcls_tools/common/measurements/profile.py
@@ -1,0 +1,169 @@
+import os
+import time
+from datetime import datetime
+from threading import Thread
+from typing import Optional, List, Dict, Any
+
+import h5py
+import numpy as np
+import pandas as pd
+from matplotlib import pyplot as plt
+from numpy import ndarray
+from pydantic import (
+    BaseModel,
+    DirectoryPath, PositiveFloat,
+)
+
+from lcls_tools.common.controls.pyepics.utils import PV
+from lcls_tools.common.data_analysis.fitting_tool import FittingTool
+from lcls_tools.common.devices.screen import Screen
+
+
+class ScreenProfileMeasurement(BaseModel):
+    device: Screen
+    fitting_tool: Optional[FittingTool] = None
+
+    save_location: Optional[DirectoryPath] = None
+    save_data: bool = True
+    extra_pvs: List[PV] = []
+    wait_time_in_seconds: PositiveFloat = 1.0
+    condition_list: List = []
+
+    def measure_profile(
+            self, n_shots=1, use_conditions: bool = True
+    ) -> [dict, ndarray]:
+        images, scalar_measurements = self.acquire_images(
+            n_shots, use_conditions=use_conditions
+        )
+
+        # collect results into a single dict using pandas
+        if n_shots == 1:
+            outputs = scalar_measurements[0]
+        else:
+            # collect results into lists
+            outputs = pd.DataFrame(scalar_measurements).reset_index().to_dict(
+                orient="list")
+            outputs.pop("index")
+
+        # add beam statistics to output
+        if self.fitting_tool is not None:
+            beam_statistics = self.fitting_tool.fit_images(images)
+            for name, val in beam_statistics:
+                outputs[name] = val
+
+        # save data if requested, add filename to outputs
+        if self.save_data:
+            fname = self._generate_new_filename()
+            self._write_data_to_hdf5(
+                np.array(images), fname, outputs)
+            outputs["save_filename"] = outputs
+
+        return outputs, images
+
+    def test_measurement(self):
+        """test the beam profile measurement"""
+        outputs, images = self.measure_profile(1, use_conditions=False)
+
+        print(outputs)
+        fig, ax = plt.subplots()
+        c = ax.imshow(images[0], origin="lower")
+        fig.colorbar(c)
+
+        plt.show()
+
+    def acquire_images(self, n_shots: int = 1, threaded=False, use_conditions=True):
+        """
+        Collect and saves images to HDF5.
+        Option for threading which spawns a child process
+        in a way that dependant GUIs/Code do not hang.
+        The extra_metadata dictionary will be attached
+        to the metadata for each image in HDF5 .
+
+        """
+        if threaded:
+            work = Thread(
+                target=self._take_images,
+                args=[n_shots, use_conditions],
+            )
+            # normally we join after start, but that blocked the pyqt main thread
+            # so we do not join here. If it breaks, look here first..
+            work.start()
+        else:
+            return self._take_images(n_shots, use_conditions)
+
+    def _take_images(self, n_shots: int = 1, use_conditions: bool = True):
+        """
+        Performs the work for collecting images and associated scalar data for a set
+        number of shots. Conditions such as charge windowing are applied.
+
+        """
+
+        images = []
+        scalar_measurements = []
+        while len(images) < n_shots:
+            time.sleep(self.wait_time_in_seconds)
+
+            # get image and PV's at the same time
+            img = self.device.get_processed_image()
+
+            # get extra pv values
+            result = {ele.pvname: ele.caget() for ele in self.extra_pvs}
+
+            # check to make sure all measurement conditions are satisfied
+            # if a condition is not satisfied then continue
+            if use_conditions:
+                for condition in self.condition_list:
+                    is_satisfied = condition.evaluate()
+                    result = result | condition.measurements()
+                    if not is_satisfied:
+                        continue
+
+            # if all conditions are satisfied then add the image and extra pv data to
+            # the list
+            images += [img]
+            scalar_measurements += [result]
+
+        return images, scalar_measurements
+
+    def _generate_new_filename(self, extension: Optional[str] = ".h5") -> str:
+        """
+        Make a new filename for the HDF5 image file
+        Should be of the form: <save-location>/<timestamp>_<screen_name>.h5
+        """
+        stamp = datetime.now().isoformat()
+        stamp_str = stamp.replace(".", "_").replace("-", "_").replace(":", "_")
+        filename = stamp_str + "_" + self.name + extension
+        path = str(os.path.join(self._root_hdf5_location, filename))
+        return path
+
+    def _write_data_to_hdf5(
+            self,
+            images: np.ndarray,
+            filename: str,
+            extra_metadata: Optional[Dict[str, Any]] = None,
+    ):
+        """
+        Saves a set of images to the hdf_save_location with the filename provided.
+        Any metadata provided as extra_metadata will be attached to each dataset in the HDF5 file.
+        """
+        with h5py.File(filename, "a") as f:
+            capture_num = 0
+            for image in images:
+                # todo, check type-representation of images, are we sure they are unsigned-shorts??
+                dset = f.create_dataset(
+                    name=str(capture_num), data=image, dtype=np.ushort
+                )
+                [dset.attrs.update({key: value}) for key, value in self.metadata]
+                if extra_metadata:
+                    # dset.attrs acts as a dictionary here
+                    # we update with original key if it isn't in our normal screen metadata
+                    # otherwise, prepend user_ to the key to retain all information.
+                    [
+                        dset.attrs.update({key: value})
+                        if key not in self.metadata
+                        else dset.attrs.update({"user_" + key: value})
+                        for key, value in extra_metadata.items()
+                    ]
+
+                capture_num += 1
+        return


### PR DESCRIPTION
This PR does the following: **These are major changes so I'm certainly looking for feedback on how you want to do this**:
- splits the functionality of the screen class into two, a device object that represents the screen object along with associated properties, and a ScreenProfileMeasurement object that combines the device info with the fitting tool to create a measurement. 
- moves saving images and metadata to measurement class since these specifications are relevant more to the measurement process not the hardware object (I think we can have more discussion about this)
- adds a method to the screen object that can measure a background and save that info to file, incl. methods to shutter the beam
- removes some of the timeout logic because it doesn't seem necessary since the operations are blocking, we could also move this logic to the PV class -- there might be something that I'm missing that you guys identified earlier
- adds a yaml env file
