### PR TITLE
updating python version for workflow/actions

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -19,10 +19,13 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python 3.8
+    - name: Set up Python 3.x
       uses: actions/setup-python@v3
       with:
-        python-version: "3.8"
+        python-version: |
+        3.8
+        3.9
+        3.10
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip


### PR DESCRIPTION
Following advanced usage example here: https://github.com/actions/setup-python/blob/main/docs/advanced-usage.md

Python versions 3.9 and 3.10 were added as options for formatting and unittest workflows.

#147 