### PR TITLE
Pydantic lcls base model

### DIFF
--- a/lcls_tools/common/__init__.py
+++ b/lcls_tools/common/__init__.py
@@ -1,0 +1,3 @@
+from lcls_tools.common.pydantic import BaseModel
+
+__all__ = ["BaseModel"]

--- a/lcls_tools/common/devices/area.py
+++ b/lcls_tools/common/devices/area.py
@@ -20,10 +20,12 @@ from lcls_tools.common.devices.wire import (
     WireCollection,
 )
 
-from pydantic import BaseModel, SerializeAsAny, Field, field_validator
+from pydantic import SerializeAsAny, Field, field_validator
+
+from lcls_tools.common.pydantic import LCLSToolsBaseModel
 
 
-class Area(BaseModel):
+class Area(LCLSToolsBaseModel):
     """This class provides access to collections of hardware components
     in a given machine area of LCLS/LCLS-II (for example: BC1, or BC2).
     The information for each collection is provided in YAML configuration

--- a/lcls_tools/common/devices/area.py
+++ b/lcls_tools/common/devices/area.py
@@ -22,10 +22,10 @@ from lcls_tools.common.devices.wire import (
 
 from pydantic import SerializeAsAny, Field, field_validator
 
-from lcls_tools.common.pydantic import LCLSToolsBaseModel
+from lcls_tools.common.pydantic import LCLSBaseModel
 
 
-class Area(LCLSToolsBaseModel):
+class Area(LCLSBaseModel):
     """This class provides access to collections of hardware components
     in a given machine area of LCLS/LCLS-II (for example: BC1, or BC2).
     The information for each collection is provided in YAML configuration

--- a/lcls_tools/common/devices/area.py
+++ b/lcls_tools/common/devices/area.py
@@ -22,10 +22,10 @@ from lcls_tools.common.devices.wire import (
 
 from pydantic import SerializeAsAny, Field, field_validator
 
-from lcls_tools.common.pydantic import LCLSBaseModel
+import lcls_tools
 
 
-class Area(LCLSBaseModel):
+class Area(lcls_tools.common.BaseModel):
     """This class provides access to collections of hardware components
     in a given machine area of LCLS/LCLS-II (for example: BC1, or BC2).
     The information for each collection is provided in YAML configuration

--- a/lcls_tools/common/devices/beampath.py
+++ b/lcls_tools/common/devices/beampath.py
@@ -13,10 +13,10 @@ from pydantic import (
     SerializeAsAny,
 )
 
-from lcls_tools.common.pydantic import LCLSToolsBaseModel
+from lcls_tools.common.pydantic import LCLSBaseModel
 
 
-class Beampath(LCLSToolsBaseModel):
+class Beampath(LCLSBaseModel):
     """This class provides access to collections of machine areas
     in a beampath of LCLS/LCLS-II (for example: CU_SXR, or SC_HXR).
     The information for each collection is provided in YAML configuration

--- a/lcls_tools/common/devices/beampath.py
+++ b/lcls_tools/common/devices/beampath.py
@@ -10,12 +10,13 @@ from lcls_tools.common.devices.area import (
 
 
 from pydantic import (
-    BaseModel,
     SerializeAsAny,
 )
 
+from lcls_tools.common.pydantic import LCLSToolsBaseModel
 
-class Beampath(BaseModel):
+
+class Beampath(LCLSToolsBaseModel):
     """This class provides access to collections of machine areas
     in a beampath of LCLS/LCLS-II (for example: CU_SXR, or SC_HXR).
     The information for each collection is provided in YAML configuration

--- a/lcls_tools/common/devices/beampath.py
+++ b/lcls_tools/common/devices/beampath.py
@@ -13,10 +13,10 @@ from pydantic import (
     SerializeAsAny,
 )
 
-from lcls_tools.common.pydantic import LCLSBaseModel
+import lcls_tools
 
 
-class Beampath(LCLSBaseModel):
+class Beampath(lcls_tools.common.BaseModel):
     """This class provides access to collections of machine areas
     in a beampath of LCLS/LCLS-II (for example: CU_SXR, or SC_HXR).
     The information for each collection is provided in YAML configuration

--- a/lcls_tools/common/devices/device.py
+++ b/lcls_tools/common/devices/device.py
@@ -2,10 +2,10 @@ from pydantic import SerializeAsAny, ConfigDict, field_validator
 from typing import List, Union, Callable, Dict, Optional
 from epics import PV
 
-from lcls_tools.common.pydantic import LCLSToolsBaseModel
+from lcls_tools.common.pydantic import LCLSBaseModel
 
 
-class PVSet(LCLSToolsBaseModel):
+class PVSet(LCLSBaseModel):
     model_config = ConfigDict(
         arbitrary_types_allowed=True,
         extra="forbid",
@@ -14,7 +14,7 @@ class PVSet(LCLSToolsBaseModel):
     ...
 
 
-class ControlInformation(LCLSToolsBaseModel):
+class ControlInformation(LCLSBaseModel):
     model_config = ConfigDict(
         frozen=True,
     )
@@ -35,7 +35,7 @@ class ControlInformation(LCLSToolsBaseModel):
         )
 
 
-class Metadata(LCLSToolsBaseModel):
+class Metadata(LCLSBaseModel):
     area: str
     beam_path: List[str]
     sum_l_meters: Union[float, None]
@@ -88,7 +88,7 @@ class RemoveDeviceCallbackError(Exception):
         )
 
 
-class Device(LCLSToolsBaseModel):
+class Device(LCLSBaseModel):
     name: str = None
     controls_information: SerializeAsAny[ControlInformation]
     metadata: SerializeAsAny[Metadata]
@@ -230,7 +230,7 @@ class Device(LCLSToolsBaseModel):
         raise NotImplementedError
 
 
-class DeviceCollection(LCLSToolsBaseModel):
+class DeviceCollection(LCLSBaseModel):
     devices: Dict[str, SerializeAsAny[Device]] = None
 
     @field_validator("devices", mode="before")

--- a/lcls_tools/common/devices/device.py
+++ b/lcls_tools/common/devices/device.py
@@ -2,10 +2,10 @@ from pydantic import SerializeAsAny, ConfigDict, field_validator
 from typing import List, Union, Callable, Dict, Optional
 from epics import PV
 
-from lcls_tools.common.pydantic import LCLSBaseModel
+import lcls_tools
 
 
-class PVSet(LCLSBaseModel):
+class PVSet(lcls_tools.common.BaseModel):
     model_config = ConfigDict(
         arbitrary_types_allowed=True,
         extra="forbid",
@@ -14,7 +14,7 @@ class PVSet(LCLSBaseModel):
     ...
 
 
-class ControlInformation(LCLSBaseModel):
+class ControlInformation(lcls_tools.common.BaseModel):
     model_config = ConfigDict(
         frozen=True,
     )
@@ -35,7 +35,7 @@ class ControlInformation(LCLSBaseModel):
         )
 
 
-class Metadata(LCLSBaseModel):
+class Metadata(lcls_tools.common.BaseModel):
     area: str
     beam_path: List[str]
     sum_l_meters: Union[float, None]
@@ -88,7 +88,7 @@ class RemoveDeviceCallbackError(Exception):
         )
 
 
-class Device(LCLSBaseModel):
+class Device(lcls_tools.common.BaseModel):
     name: str = None
     controls_information: SerializeAsAny[ControlInformation]
     metadata: SerializeAsAny[Metadata]
@@ -230,7 +230,7 @@ class Device(LCLSBaseModel):
         raise NotImplementedError
 
 
-class DeviceCollection(LCLSBaseModel):
+class DeviceCollection(lcls_tools.common.BaseModel):
     devices: Dict[str, SerializeAsAny[Device]] = None
 
     @field_validator("devices", mode="before")

--- a/lcls_tools/common/devices/device.py
+++ b/lcls_tools/common/devices/device.py
@@ -1,9 +1,11 @@
-from pydantic import BaseModel, SerializeAsAny, ConfigDict, field_validator
+from pydantic import SerializeAsAny, ConfigDict, field_validator
 from typing import List, Union, Callable, Dict, Optional
 from epics import PV
 
+from lcls_tools.common.pydantic import LCLSToolsBaseModel
 
-class PVSet(BaseModel):
+
+class PVSet(LCLSToolsBaseModel):
     model_config = ConfigDict(
         arbitrary_types_allowed=True,
         extra="forbid",
@@ -12,7 +14,7 @@ class PVSet(BaseModel):
     ...
 
 
-class ControlInformation(BaseModel):
+class ControlInformation(LCLSToolsBaseModel):
     model_config = ConfigDict(
         frozen=True,
     )
@@ -33,7 +35,7 @@ class ControlInformation(BaseModel):
         )
 
 
-class Metadata(BaseModel):
+class Metadata(LCLSToolsBaseModel):
     area: str
     beam_path: List[str]
     sum_l_meters: Union[float, None]
@@ -86,7 +88,7 @@ class RemoveDeviceCallbackError(Exception):
         )
 
 
-class Device(BaseModel):
+class Device(LCLSToolsBaseModel):
     name: str = None
     controls_information: SerializeAsAny[ControlInformation]
     metadata: SerializeAsAny[Metadata]
@@ -228,7 +230,7 @@ class Device(BaseModel):
         raise NotImplementedError
 
 
-class DeviceCollection(BaseModel):
+class DeviceCollection(LCLSToolsBaseModel):
     devices: Dict[str, SerializeAsAny[Device]] = None
 
     @field_validator("devices", mode="before")

--- a/lcls_tools/common/devices/device.py
+++ b/lcls_tools/common/devices/device.py
@@ -39,6 +39,9 @@ class Metadata(lcls_tools.common.BaseModel):
     area: str
     beam_path: List[str]
     sum_l_meters: Union[float, None]
+    type: Optional[str] = None
+    safe_level: Optional[float] = None
+    read_tolerance: Optional[float] = None
 
     def __init__(
         self,

--- a/lcls_tools/common/devices/lblm.py
+++ b/lcls_tools/common/devices/lblm.py
@@ -21,20 +21,20 @@ from lcls_tools.common.devices.device import (
 )
 from epics import PV
 
-from lcls_tools.common.pydantic import LCLSToolsBaseModel
+from lcls_tools.common.pydantic import LCLSBaseModel
 
 EPICS_ERROR_MESSAGE = "Unable to connect to EPICS."
 
 
-class BooleanModel(LCLSToolsBaseModel):
+class BooleanModel(LCLSBaseModel):
     value: bool
 
 
-class FloatModel(LCLSToolsBaseModel):
+class FloatModel(LCLSBaseModel):
     value: float
 
 
-class IntegerModel(LCLSToolsBaseModel):
+class IntegerModel(LCLSBaseModel):
     value: conint(strict=True)
 
 

--- a/lcls_tools/common/devices/lblm.py
+++ b/lcls_tools/common/devices/lblm.py
@@ -21,20 +21,20 @@ from lcls_tools.common.devices.device import (
 )
 from epics import PV
 
-from lcls_tools.common.pydantic import LCLSBaseModel
+import lcls_tools
 
 EPICS_ERROR_MESSAGE = "Unable to connect to EPICS."
 
 
-class BooleanModel(LCLSBaseModel):
+class BooleanModel(lcls_tools.common.BaseModel):
     value: bool
 
 
-class FloatModel(LCLSBaseModel):
+class FloatModel(lcls_tools.common.BaseModel):
     value: float
 
 
-class IntegerModel(LCLSBaseModel):
+class IntegerModel(lcls_tools.common.BaseModel):
     value: conint(strict=True)
 
 

--- a/lcls_tools/common/devices/lblm.py
+++ b/lcls_tools/common/devices/lblm.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from pydantic import (
-    BaseModel,
     # PositiveFloat,
+    BaseModel,
     SerializeAsAny,
     field_validator,
     conint,
@@ -21,18 +21,20 @@ from lcls_tools.common.devices.device import (
 )
 from epics import PV
 
+from lcls_tools.common.pydantic import LCLSToolsBaseModel
+
 EPICS_ERROR_MESSAGE = "Unable to connect to EPICS."
 
 
-class BooleanModel(BaseModel):
+class BooleanModel(LCLSToolsBaseModel):
     value: bool
 
 
-class FloatModel(BaseModel):
+class FloatModel(LCLSToolsBaseModel):
     value: float
 
 
-class IntegerModel(BaseModel):
+class IntegerModel(LCLSToolsBaseModel):
     value: conint(strict=True)
 
 

--- a/lcls_tools/common/devices/magnet.py
+++ b/lcls_tools/common/devices/magnet.py
@@ -180,7 +180,7 @@ class Magnet(Device):
     def bmin(self) -> float:
         """Get minimum magnetic field value in kG or kG-m^x."""
         return self.controls_information.PVs.bmin.get()
-    
+
     @property
     def type(self) -> str:
         return self.metadata.type
@@ -188,7 +188,7 @@ class Magnet(Device):
     @property
     def safe_level(self) -> float:
         return self.metadata.safe_level
-    
+
     @property
     def read_tolerance(self) -> float:
         return self.metadata.read_tolerance

--- a/lcls_tools/common/devices/magnet.py
+++ b/lcls_tools/common/devices/magnet.py
@@ -62,7 +62,6 @@ class MagnetControlInformation(ControlInformation):
 class MagnetMetadata(Metadata):
     l_eff: Optional[NonNegativeFloat] = None
     b_tolerance: Optional[PositiveFloat] = None
-    type: Optional[str] = None
 
     def __init__(self, *args, **kwargs):
         super(MagnetMetadata, self).__init__(*args, **kwargs)
@@ -181,6 +180,18 @@ class Magnet(Device):
     def bmin(self) -> float:
         """Get minimum magnetic field value in kG or kG-m^x."""
         return self.controls_information.PVs.bmin.get()
+    
+    @property
+    def type(self) -> str:
+        return self.metadata.type
+
+    @property
+    def safe_level(self) -> float:
+        return self.metadata.safe_level
+    
+    @property
+    def read_tolerance(self) -> float:
+        return self.metadata.read_tolerance
 
     def is_bact_settled(self, b_tolerance: Optional[float] = 0.0) -> bool:
         return abs(self.bdes) - abs(self.bact) < b_tolerance

--- a/lcls_tools/common/devices/magnet.py
+++ b/lcls_tools/common/devices/magnet.py
@@ -62,6 +62,7 @@ class MagnetControlInformation(ControlInformation):
 class MagnetMetadata(Metadata):
     l_eff: Optional[NonNegativeFloat] = None
     b_tolerance: Optional[PositiveFloat] = None
+    type: Optional[str] = None
 
     def __init__(self, *args, **kwargs):
         super(MagnetMetadata, self).__init__(*args, **kwargs)

--- a/lcls_tools/common/devices/screen.py
+++ b/lcls_tools/common/devices/screen.py
@@ -237,14 +237,14 @@ class Screen(Device):
                 dset = f.create_dataset(
                     name=str(capture_num), data=image, dtype=np.ushort
                 )
-                [dset.attrs.update({key: value}) for key, value in self.metadata]
+                [dset.attrs.update({key: value or h5py.Empty("f4")}) for key, value in self.metadata]
                 if extra_metadata:
                     # dset.attrs acts as a dictionary here
                     # we update with original key if it isn't in our normal screen metadata
                     # otherwise, prepend user_ to the key to retain all information.
                     [
                         (
-                            dset.attrs.update({key: value})
+                            dset.attrs.update({key: value or h5py.Empty("f4")})
                             if key not in self.metadata
                             else dset.attrs.update({"user_" + key: value})
                         )

--- a/lcls_tools/common/devices/wire.py
+++ b/lcls_tools/common/devices/wire.py
@@ -496,7 +496,7 @@ class Wire(Device):
     @property
     def safe_level(self) -> float:
         return self.metadata.safe_level
-    
+
     @property
     def read_tolerance(self) -> float:
         return self.metadata.read_tolerance

--- a/lcls_tools/common/devices/wire.py
+++ b/lcls_tools/common/devices/wire.py
@@ -20,12 +20,12 @@ from lcls_tools.common.devices.device import (
 )
 from epics import PV
 
-from lcls_tools.common.pydantic import LCLSToolsBaseModel
+from lcls_tools.common.pydantic import LCLSBaseModel
 
 EPICS_ERROR_MESSAGE = "Unable to connect to EPICS."
 
 
-class RangeModel(LCLSToolsBaseModel):
+class RangeModel(LCLSBaseModel):
     value: list
 
     @field_validator('value')
@@ -38,15 +38,15 @@ class RangeModel(LCLSToolsBaseModel):
             return v
 
 
-class BooleanModel(LCLSToolsBaseModel):
+class BooleanModel(LCLSBaseModel):
     value: bool
 
 
-class IntegerModel(LCLSToolsBaseModel):
+class IntegerModel(LCLSBaseModel):
     value: conint(strict=True)
 
 
-class PlaneModel(LCLSToolsBaseModel):
+class PlaneModel(LCLSBaseModel):
     plane: str
 
     @field_validator('plane')
@@ -490,7 +490,7 @@ class Wire(Device):
             print("Range value must be an int:", e)
 
 
-class WireCollection(LCLSToolsBaseModel):
+class WireCollection(LCLSBaseModel):
     wires: Dict[str, SerializeAsAny[Wire]]
 
     @field_validator("wires", mode="before")

--- a/lcls_tools/common/devices/wire.py
+++ b/lcls_tools/common/devices/wire.py
@@ -489,6 +489,18 @@ class Wire(Device):
         except ValidationError as e:
             print("Range value must be an int:", e)
 
+    @property
+    def type(self) -> str:
+        return self.metadata.type
+
+    @property
+    def safe_level(self) -> float:
+        return self.metadata.safe_level
+    
+    @property
+    def read_tolerance(self) -> float:
+        return self.metadata.read_tolerance
+
 
 class WireCollection(lcls_tools.common.BaseModel):
     wires: Dict[str, SerializeAsAny[Wire]]

--- a/lcls_tools/common/devices/wire.py
+++ b/lcls_tools/common/devices/wire.py
@@ -1,6 +1,5 @@
 from datetime import datetime
 from pydantic import (
-    BaseModel,
     # PositiveFloat,
     SerializeAsAny,
     field_validator,
@@ -21,10 +20,12 @@ from lcls_tools.common.devices.device import (
 )
 from epics import PV
 
+from lcls_tools.common.pydantic import LCLSToolsBaseModel
+
 EPICS_ERROR_MESSAGE = "Unable to connect to EPICS."
 
 
-class RangeModel(BaseModel):
+class RangeModel(LCLSToolsBaseModel):
     value: list
 
     @field_validator('value')
@@ -37,15 +38,15 @@ class RangeModel(BaseModel):
             return v
 
 
-class BooleanModel(BaseModel):
+class BooleanModel(LCLSToolsBaseModel):
     value: bool
 
 
-class IntegerModel(BaseModel):
+class IntegerModel(LCLSToolsBaseModel):
     value: conint(strict=True)
 
 
-class PlaneModel(BaseModel):
+class PlaneModel(LCLSToolsBaseModel):
     plane: str
 
     @field_validator('plane')

--- a/lcls_tools/common/devices/wire.py
+++ b/lcls_tools/common/devices/wire.py
@@ -20,12 +20,12 @@ from lcls_tools.common.devices.device import (
 )
 from epics import PV
 
-from lcls_tools.common.pydantic import LCLSBaseModel
+import lcls_tools
 
 EPICS_ERROR_MESSAGE = "Unable to connect to EPICS."
 
 
-class RangeModel(LCLSBaseModel):
+class RangeModel(lcls_tools.common.BaseModel):
     value: list
 
     @field_validator('value')
@@ -38,15 +38,15 @@ class RangeModel(LCLSBaseModel):
             return v
 
 
-class BooleanModel(LCLSBaseModel):
+class BooleanModel(lcls_tools.common.BaseModel):
     value: bool
 
 
-class IntegerModel(LCLSBaseModel):
+class IntegerModel(lcls_tools.common.BaseModel):
     value: conint(strict=True)
 
 
-class PlaneModel(LCLSBaseModel):
+class PlaneModel(lcls_tools.common.BaseModel):
     plane: str
 
     @field_validator('plane')
@@ -490,7 +490,7 @@ class Wire(Device):
             print("Range value must be an int:", e)
 
 
-class WireCollection(LCLSBaseModel):
+class WireCollection(lcls_tools.common.BaseModel):
     wires: Dict[str, SerializeAsAny[Wire]]
 
     @field_validator("wires", mode="before")

--- a/lcls_tools/common/devices/wire.py
+++ b/lcls_tools/common/devices/wire.py
@@ -490,7 +490,7 @@ class Wire(Device):
             print("Range value must be an int:", e)
 
 
-class WireCollection(BaseModel):
+class WireCollection(LCLSToolsBaseModel):
     wires: Dict[str, SerializeAsAny[Wire]]
 
     @field_validator("wires", mode="before")

--- a/lcls_tools/common/image/fit.py
+++ b/lcls_tools/common/image/fit.py
@@ -25,7 +25,7 @@ class ImageProjectionFitResult(ImageFitResult):
     y_projection_fit_parameters: dict[str, float]
 
 
-class ImageFit(LCLSBaseModel, ABC):
+class ImageFit(lcls_tools.common.BaseModel, ABC):
     """
     Abstract class for determining beam properties from an image
     """

--- a/lcls_tools/common/image/fit.py
+++ b/lcls_tools/common/image/fit.py
@@ -9,10 +9,10 @@ from lcls_tools.common.data.fit.method_base import MethodBase
 from lcls_tools.common.data.fit.methods import GaussianModel
 from lcls_tools.common.data.fit.projection import ProjectionFit
 from lcls_tools.common.measurements.utils import NDArrayAnnotatedType
-from lcls_tools.common.pydantic import LCLSToolsBaseModel
+from lcls_tools.common.pydantic import LCLSBaseModel
 
 
-class ImageFitResult(LCLSToolsBaseModel):
+class ImageFitResult(LCLSBaseModel):
     centroid: List[float] = Field(min_length=2, max_length=2)
     rms_size: List[float] = Field(min_length=2, max_length=2)
     total_intensity: PositiveFloat
@@ -25,7 +25,7 @@ class ImageProjectionFitResult(ImageFitResult):
     y_projection_fit_parameters: dict[str, float]
 
 
-class ImageFit(LCLSToolsBaseModel, ABC):
+class ImageFit(LCLSBaseModel, ABC):
     """
     Abstract class for determining beam properties from an image
     """

--- a/lcls_tools/common/image/fit.py
+++ b/lcls_tools/common/image/fit.py
@@ -9,10 +9,10 @@ from lcls_tools.common.data.fit.method_base import MethodBase
 from lcls_tools.common.data.fit.methods import GaussianModel
 from lcls_tools.common.data.fit.projection import ProjectionFit
 from lcls_tools.common.measurements.utils import NDArrayAnnotatedType
-from lcls_tools.common.pydantic import LCLSBaseModel
+import lcls_tools
 
 
-class ImageFitResult(LCLSBaseModel):
+class ImageFitResult(lcls_tools.common.BaseModel):
     centroid: List[float] = Field(min_length=2, max_length=2)
     rms_size: List[float] = Field(min_length=2, max_length=2)
     total_intensity: PositiveFloat

--- a/lcls_tools/common/image/fit.py
+++ b/lcls_tools/common/image/fit.py
@@ -3,7 +3,7 @@ from typing import Optional, List
 
 import numpy as np
 from numpy import ndarray
-from pydantic import ConfigDict, PositiveFloat, Field
+from pydantic import PositiveFloat, Field
 
 from lcls_tools.common.data.fit.method_base import MethodBase
 from lcls_tools.common.data.fit.methods import GaussianModel

--- a/lcls_tools/common/image/fit.py
+++ b/lcls_tools/common/image/fit.py
@@ -3,20 +3,20 @@ from typing import Optional, List
 
 import numpy as np
 from numpy import ndarray
-from pydantic import BaseModel, ConfigDict, PositiveFloat, Field
+from pydantic import ConfigDict, PositiveFloat, Field
 
 from lcls_tools.common.data.fit.method_base import MethodBase
 from lcls_tools.common.data.fit.methods import GaussianModel
 from lcls_tools.common.data.fit.projection import ProjectionFit
 from lcls_tools.common.measurements.utils import NDArrayAnnotatedType
+from lcls_tools.common.pydantic import LCLSToolsBaseModel
 
 
-class ImageFitResult(BaseModel):
+class ImageFitResult(LCLSToolsBaseModel):
     centroid: List[float] = Field(min_length=2, max_length=2)
     rms_size: List[float] = Field(min_length=2, max_length=2)
     total_intensity: PositiveFloat
     image: NDArrayAnnotatedType
-    model_config = ConfigDict(arbitrary_types_allowed=True)
 
 
 class ImageProjectionFitResult(ImageFitResult):
@@ -25,12 +25,10 @@ class ImageProjectionFitResult(ImageFitResult):
     y_projection_fit_parameters: dict[str, float]
 
 
-class ImageFit(BaseModel, ABC):
+class ImageFit(LCLSToolsBaseModel, ABC):
     """
     Abstract class for determining beam properties from an image
     """
-    model_config = ConfigDict(arbitrary_types_allowed=True)
-
     def fit_image(self, image: ndarray) -> ImageFitResult:
         """
         Public method to determine beam properties from an image, including initial
@@ -56,7 +54,6 @@ class ImageProjectionFit(ImageFit):
     profile with prior distributions placed on the model parameters.
     """
     projection_fit_method: Optional[MethodBase] = GaussianModel(use_priors=True)
-    model_config = ConfigDict(arbitrary_types_allowed=True)
 
     def _fit_image(self, image: ndarray) -> ImageProjectionFitResult:
         x_projection = np.array(np.sum(image, axis=0))

--- a/lcls_tools/common/image/processing.py
+++ b/lcls_tools/common/image/processing.py
@@ -5,10 +5,10 @@ import numpy as np
 from scipy.ndimage import gaussian_filter, median_filter
 from pydantic import PositiveFloat, ConfigDict
 from lcls_tools.common.image.roi import ROI
-from lcls_tools.common.pydantic import LCLSBaseModel
+import lcls_tools
 
 
-class ImageProcessor(LCLSBaseModel):
+class ImageProcessor(lcls_tools.common.BaseModel):
     """
     Image Processing class that allows for background subtraction and roi cropping
     ------------------------

--- a/lcls_tools/common/image/processing.py
+++ b/lcls_tools/common/image/processing.py
@@ -5,10 +5,10 @@ import numpy as np
 from scipy.ndimage import gaussian_filter, median_filter
 from pydantic import PositiveFloat, ConfigDict
 from lcls_tools.common.image.roi import ROI
-from lcls_tools.common.pydantic import LCLSToolsBaseModel
+from lcls_tools.common.pydantic import LCLSBaseModel
 
 
-class ImageProcessor(LCLSToolsBaseModel):
+class ImageProcessor(LCLSBaseModel):
     """
     Image Processing class that allows for background subtraction and roi cropping
     ------------------------

--- a/lcls_tools/common/image/processing.py
+++ b/lcls_tools/common/image/processing.py
@@ -3,11 +3,12 @@ from typing import Optional
 
 import numpy as np
 from scipy.ndimage import gaussian_filter, median_filter
-from pydantic import BaseModel, PositiveFloat, ConfigDict
+from pydantic import PositiveFloat, ConfigDict
 from lcls_tools.common.image.roi import ROI
+from lcls_tools.common.pydantic import LCLSToolsBaseModel
 
 
-class ImageProcessor(BaseModel):
+class ImageProcessor(LCLSToolsBaseModel):
     """
     Image Processing class that allows for background subtraction and roi cropping
     ------------------------

--- a/lcls_tools/common/image/roi.py
+++ b/lcls_tools/common/image/roi.py
@@ -1,13 +1,14 @@
 import numpy as np
 from pydantic import (
-    BaseModel,
     model_validator,
     PositiveFloat
 )
 from typing import Any, Dict, List
 
+from lcls_tools.common.pydantic import LCLSToolsBaseModel
 
-class ROI(BaseModel):
+
+class ROI(LCLSToolsBaseModel):
     center: List[PositiveFloat]
     extent: List[PositiveFloat]
 

--- a/lcls_tools/common/image/roi.py
+++ b/lcls_tools/common/image/roi.py
@@ -5,10 +5,10 @@ from pydantic import (
 )
 from typing import Any, Dict, List
 
-from lcls_tools.common.pydantic import LCLSBaseModel
+import lcls_tools
 
 
-class ROI(LCLSBaseModel):
+class ROI(lcls_tools.common.BaseModel):
     center: List[PositiveFloat]
     extent: List[PositiveFloat]
 

--- a/lcls_tools/common/image/roi.py
+++ b/lcls_tools/common/image/roi.py
@@ -5,10 +5,10 @@ from pydantic import (
 )
 from typing import Any, Dict, List
 
-from lcls_tools.common.pydantic import LCLSToolsBaseModel
+from lcls_tools.common.pydantic import LCLSBaseModel
 
 
-class ROI(LCLSToolsBaseModel):
+class ROI(LCLSBaseModel):
     center: List[PositiveFloat]
     extent: List[PositiveFloat]
 

--- a/lcls_tools/common/measurements/emittance_measurement.py
+++ b/lcls_tools/common/measurements/emittance_measurement.py
@@ -18,7 +18,7 @@ from lcls_tools.common.data.model_general_calcs import bdes_to_kmod, get_optics
 from lcls_tools.common.devices.magnet import Magnet
 from lcls_tools.common.measurements.measurement import Measurement
 from lcls_tools.common.measurements.utils import NDArrayAnnotatedType
-from lcls_tools.common.pydantic import LCLSToolsBaseModel
+from lcls_tools.common.pydantic import LCLSBaseModel
 
 
 class BMAGMode(enum.IntEnum):
@@ -44,7 +44,7 @@ class BMAGMode(enum.IntEnum):
         raise ValueError(f"invalid {cls.__name__}={value} must be one of: {_members()}")
 
 
-class EmittanceMeasurementResult(LCLSToolsBaseModel):
+class EmittanceMeasurementResult(LCLSBaseModel):
     """
     EmittanceMeasurementResult stores the results of an emittance measurement.
 

--- a/lcls_tools/common/measurements/emittance_measurement.py
+++ b/lcls_tools/common/measurements/emittance_measurement.py
@@ -18,7 +18,7 @@ from lcls_tools.common.data.model_general_calcs import bdes_to_kmod, get_optics
 from lcls_tools.common.devices.magnet import Magnet
 from lcls_tools.common.measurements.measurement import Measurement
 from lcls_tools.common.measurements.utils import NDArrayAnnotatedType
-from lcls_tools.common.pydantic import LCLSBaseModel
+import lcls_tools
 
 
 class BMAGMode(enum.IntEnum):
@@ -44,7 +44,7 @@ class BMAGMode(enum.IntEnum):
         raise ValueError(f"invalid {cls.__name__}={value} must be one of: {_members()}")
 
 
-class EmittanceMeasurementResult(LCLSBaseModel):
+class EmittanceMeasurementResult(lcls_tools.common.BaseModel):
     """
     EmittanceMeasurementResult stores the results of an emittance measurement.
 

--- a/lcls_tools/common/measurements/emittance_measurement.py
+++ b/lcls_tools/common/measurements/emittance_measurement.py
@@ -284,7 +284,6 @@ class QuadScanEmittance(Measurement):
 
             results["rms_beamsizes"].append(single_beam_size)
 
-        #results.update({"info": self._info})
         results.update({"metadata": self.model_dump()})
 
         # collect information into EmittanceMeasurementResult object

--- a/lcls_tools/common/measurements/emittance_measurement.py
+++ b/lcls_tools/common/measurements/emittance_measurement.py
@@ -6,7 +6,6 @@ from typing import Any, List, Optional
 import numpy as np
 from numpy import ndarray
 from pydantic import (
-    BaseModel,
     ConfigDict,
     PositiveInt,
     SerializeAsAny,
@@ -19,6 +18,7 @@ from lcls_tools.common.data.model_general_calcs import bdes_to_kmod, get_optics
 from lcls_tools.common.devices.magnet import Magnet
 from lcls_tools.common.measurements.measurement import Measurement
 from lcls_tools.common.measurements.utils import NDArrayAnnotatedType
+from lcls_tools.common.pydantic import LCLSToolsBaseModel
 
 
 class BMAGMode(enum.IntEnum):
@@ -44,7 +44,7 @@ class BMAGMode(enum.IntEnum):
         raise ValueError(f"invalid {cls.__name__}={value} must be one of: {_members()}")
 
 
-class EmittanceMeasurementResult(BaseModel):
+class EmittanceMeasurementResult(LCLSToolsBaseModel):
     """
     EmittanceMeasurementResult stores the results of an emittance measurement.
 
@@ -78,8 +78,6 @@ class EmittanceMeasurementResult(BaseModel):
     rms_beamsizes: List[NDArrayAnnotatedType]
     beam_matrix: NDArrayAnnotatedType
     metadata: SerializeAsAny[Any]
-
-    model_config = ConfigDict(arbitrary_types_allowed=True)
 
     def get_best_bmag(self, mode=BMAGMode.GEOMETRIC_MEAN) -> tuple:
         """

--- a/lcls_tools/common/measurements/emittance_measurement.py
+++ b/lcls_tools/common/measurements/emittance_measurement.py
@@ -284,7 +284,7 @@ class QuadScanEmittance(Measurement):
 
             results["rms_beamsizes"].append(single_beam_size)
 
-        results.update({"info": self._info})
+        #results.update({"info": self._info})
         results.update({"metadata": self.model_dump()})
 
         # collect information into EmittanceMeasurementResult object

--- a/lcls_tools/common/measurements/measurement.py
+++ b/lcls_tools/common/measurements/measurement.py
@@ -6,7 +6,7 @@ from pydantic import DirectoryPath
 import lcls_tools
 
 
-class Measurement(LCLSBaseModel, ABC):
+class Measurement(lcls_tools.common.BaseModel, ABC):
     name: str
     save_data: bool = True
     save_location: Optional[DirectoryPath] = None

--- a/lcls_tools/common/measurements/measurement.py
+++ b/lcls_tools/common/measurements/measurement.py
@@ -1,10 +1,12 @@
 from abc import ABC, abstractmethod
 from typing import Optional
 
-from pydantic import BaseModel, DirectoryPath
+from pydantic import DirectoryPath
+
+from lcls_tools.common.pydantic import LCLSToolsBaseModel
 
 
-class Measurement(BaseModel, ABC):
+class Measurement(LCLSToolsBaseModel, ABC):
     name: str
     save_data: bool = True
     save_location: Optional[DirectoryPath] = None

--- a/lcls_tools/common/measurements/measurement.py
+++ b/lcls_tools/common/measurements/measurement.py
@@ -3,10 +3,10 @@ from typing import Optional
 
 from pydantic import DirectoryPath
 
-from lcls_tools.common.pydantic import LCLSToolsBaseModel
+from lcls_tools.common.pydantic import LCLSBaseModel
 
 
-class Measurement(LCLSToolsBaseModel, ABC):
+class Measurement(LCLSBaseModel, ABC):
     name: str
     save_data: bool = True
     save_location: Optional[DirectoryPath] = None

--- a/lcls_tools/common/measurements/measurement.py
+++ b/lcls_tools/common/measurements/measurement.py
@@ -3,7 +3,7 @@ from typing import Optional
 
 from pydantic import DirectoryPath
 
-from lcls_tools.common.pydantic import LCLSBaseModel
+import lcls_tools
 
 
 class Measurement(LCLSBaseModel, ABC):

--- a/lcls_tools/common/measurements/screen_profile.py
+++ b/lcls_tools/common/measurements/screen_profile.py
@@ -11,10 +11,10 @@ from pydantic import (
 from typing import Optional
 
 from lcls_tools.common.measurements.utils import NDArrayAnnotatedType
-from lcls_tools.common.pydantic import LCLSToolsBaseModel
+from lcls_tools.common.pydantic import LCLSBaseModel
 
 
-class ScreenBeamProfileMeasurementResult(LCLSToolsBaseModel):
+class ScreenBeamProfileMeasurementResult(LCLSBaseModel):
     """
     Class that contains the results of a beam profile measurement
 

--- a/lcls_tools/common/measurements/screen_profile.py
+++ b/lcls_tools/common/measurements/screen_profile.py
@@ -5,16 +5,16 @@ from lcls_tools.common.image.fit import ImageProjectionFit, ImageFit
 from lcls_tools.common.image.processing import ImageProcessor
 from lcls_tools.common.measurements.measurement import Measurement
 from pydantic import (
-    BaseModel,
     ConfigDict,
     SerializeAsAny,
 )
 from typing import Optional
 
 from lcls_tools.common.measurements.utils import NDArrayAnnotatedType
+from lcls_tools.common.pydantic import LCLSToolsBaseModel
 
 
-class ScreenBeamProfileMeasurementResult(BaseModel):
+class ScreenBeamProfileMeasurementResult(LCLSToolsBaseModel):
     """
     Class that contains the results of a beam profile measurement
 

--- a/lcls_tools/common/measurements/screen_profile.py
+++ b/lcls_tools/common/measurements/screen_profile.py
@@ -11,10 +11,10 @@ from pydantic import (
 from typing import Optional
 
 from lcls_tools.common.measurements.utils import NDArrayAnnotatedType
-from lcls_tools.common.pydantic import LCLSBaseModel
+import lcls_tools
 
 
-class ScreenBeamProfileMeasurementResult(LCLSBaseModel):
+class ScreenBeamProfileMeasurementResult(lcls_tools.common.BaseModel):
     """
     Class that contains the results of a beam profile measurement
 

--- a/lcls_tools/common/pydantic.py
+++ b/lcls_tools/common/pydantic.py
@@ -1,5 +1,5 @@
 from pydantic import BaseModel, ConfigDict
 
 
-class LCLSToolsBaseModel(BaseModel):
+class LCLSBaseModel(BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True, extra="forbid")

--- a/lcls_tools/common/pydantic.py
+++ b/lcls_tools/common/pydantic.py
@@ -1,0 +1,4 @@
+from pydantic import BaseModel, ConfigDict
+
+class LCLSToolsBaseModel(BaseModel):
+    model_config = ConfigDict(arbitrary_types_allowed=True, extra="forbid")

--- a/lcls_tools/common/pydantic.py
+++ b/lcls_tools/common/pydantic.py
@@ -1,4 +1,5 @@
 from pydantic import BaseModel, ConfigDict
 
+
 class LCLSToolsBaseModel(BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True, extra="forbid")

--- a/lcls_tools/common/pydantic.py
+++ b/lcls_tools/common/pydantic.py
@@ -1,5 +1,5 @@
 from pydantic import BaseModel, ConfigDict
 
 
-class LCLSBaseModel(BaseModel):
+class BaseModel(BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True, extra="forbid")

--- a/tests/unit_tests/lcls_tools/common/devices/test_screen.py
+++ b/tests/unit_tests/lcls_tools/common/devices/test_screen.py
@@ -44,9 +44,9 @@ class TestScreen(unittest.TestCase):
                 self.assertEqual(len(f), num_capture)
                 # check metadata is stored as attributes in HDF5.
                 for dataset in f:
-                    self.assertSequenceEqual(
-                        list(f[dataset].attrs.keys()),
-                        list(self.screen.metadata.model_dump().keys()),
+                    self.assertSetEqual(
+                        set(f[dataset].attrs.keys()),
+                        set(self.screen.metadata.model_dump().keys()),
                     )
                     # check dataset content for shape
                     self.assertTrue(


### PR DESCRIPTION
-  globally modifies pydantic acceptance of arbitrary types and forbids extra fields (saves us from silent failures due to typos for optional fields)