### PR TITLE
Adding refresh rate pvs and property to screens.

### DIFF
--- a/lcls_tools/common/devices/screen.py
+++ b/lcls_tools/common/devices/screen.py
@@ -39,8 +39,8 @@ class ScreenPVSet(PVSet):
     n_bits: PV
     resolution: PV
     sys_type: PV
-    ref_rate_vme: Optional[PV]
-    ref_rate: Optional[PV]
+    ref_rate_vme: Optional[PV] = None
+    ref_rate: Optional[PV] = None
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)

--- a/lcls_tools/common/devices/screen.py
+++ b/lcls_tools/common/devices/screen.py
@@ -38,6 +38,9 @@ class ScreenPVSet(PVSet):
     n_row: PV
     n_bits: PV
     resolution: PV
+    sys_type: PV
+    ref_rate_vme: Optional[PV]
+    ref_rate: Optional[PV]
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
@@ -94,6 +97,16 @@ class Screen(Device):
                 f"Could not set {self.name} HDF5 save location. Please provide an existing directory."
             )
         self._root_hdf5_location = path
+
+    @property
+    def refresh_rate(self):
+        sys_type = self.controls_information.PVs.sys_type.get()
+        if str(sys_type) == 'VME':
+            return self.controls_information.PVs.ref_rate_vme.get()
+        elif str(sys_type) == 'LinuxRT':
+            return self.controls_information.PVs.ref_rate.get()
+        else:
+            raise ValueError('Camera refresh rate not found')
 
     @property
     def is_saving_images(self):

--- a/lcls_tools/common/devices/yaml/BC1.yaml
+++ b/lcls_tools/common/devices/yaml/BC1.yaml
@@ -513,7 +513,9 @@ screens:
         n_bits: OTRS:LI21:237:N_OF_BITS
         n_col: OTRS:LI21:237:N_OF_COL
         n_row: OTRS:LI21:237:N_OF_ROW
+        ref_rate_vme: OTRS:LI21:237:FRAME_RATE
         resolution: OTRS:LI21:237:RESOLUTION
+        sys_type: OTRS:LI21:237:SYS_TYPE
       control_name: OTRS:LI21:237
     metadata:
       area: BC1
@@ -533,7 +535,9 @@ screens:
         n_bits: OTRS:LI21:291:N_OF_BITS
         n_col: OTRS:LI21:291:N_OF_COL
         n_row: OTRS:LI21:291:N_OF_ROW
+        ref_rate_vme: OTRS:LI21:291:FRAME_RATE
         resolution: OTRS:LI21:291:RESOLUTION
+        sys_type: OTRS:LI21:291:SYS_TYPE
       control_name: OTRS:LI21:291
     metadata:
       area: BC1

--- a/lcls_tools/common/devices/yaml/BC1B.yaml
+++ b/lcls_tools/common/devices/yaml/BC1B.yaml
@@ -282,7 +282,10 @@ screens:
         n_bits: PROF:BC1B:470:N_OF_BITS
         n_col: PROF:BC1B:470:Image:ArraySize1_RBV
         n_row: PROF:BC1B:470:Image:ArraySize0_RBV
+        ref_rate: PROF:BC1B:470:ArrayRate_RBV
+        ref_rate_vme: PROF:BC1B:470:FRAME_RATE
         resolution: PROF:BC1B:470:RESOLUTION
+        sys_type: PROF:BC1B:470:SYS_TYPE
       control_name: PROF:BC1B:470
     metadata:
       area: BC1B

--- a/lcls_tools/common/devices/yaml/BC2.yaml
+++ b/lcls_tools/common/devices/yaml/BC2.yaml
@@ -283,7 +283,9 @@ screens:
         n_bits: OTRS:LI24:807:N_OF_BITS
         n_col: OTRS:LI24:807:N_OF_COL
         n_row: OTRS:LI24:807:N_OF_ROW
+        ref_rate_vme: OTRS:LI24:807:FRAME_RATE
         resolution: OTRS:LI24:807:RESOLUTION
+        sys_type: OTRS:LI24:807:SYS_TYPE
       control_name: OTRS:LI24:807
     metadata:
       area: BC2

--- a/lcls_tools/common/devices/yaml/BC2B.yaml
+++ b/lcls_tools/common/devices/yaml/BC2B.yaml
@@ -232,7 +232,10 @@ screens:
         n_bits: PROF:BC2B:545:N_OF_BITS
         n_col: PROF:BC2B:545:Image:ArraySize1_RBV
         n_row: PROF:BC2B:545:Image:ArraySize0_RBV
+        ref_rate: PROF:BC2B:545:ArrayRate_RBV
+        ref_rate_vme: PROF:BC2B:545:FRAME_RATE
         resolution: PROF:BC2B:545:RESOLUTION
+        sys_type: PROF:BC2B:545:SYS_TYPE
       control_name: PROF:BC2B:545
     metadata:
       area: BC2B

--- a/lcls_tools/common/devices/yaml/COL0.yaml
+++ b/lcls_tools/common/devices/yaml/COL0.yaml
@@ -607,7 +607,10 @@ screens:
         n_bits: PROF:COL0:535:N_OF_BITS
         n_col: PROF:COL0:535:Image:ArraySize1_RBV
         n_row: PROF:COL0:535:Image:ArraySize0_RBV
+        ref_rate: PROF:COL0:535:ArrayRate_RBV
+        ref_rate_vme: PROF:COL0:535:FRAME_RATE
         resolution: PROF:COL0:535:RESOLUTION
+        sys_type: PROF:COL0:535:SYS_TYPE
       control_name: PROF:COL0:535
     metadata:
       area: COL0

--- a/lcls_tools/common/devices/yaml/DASEL.yaml
+++ b/lcls_tools/common/devices/yaml/DASEL.yaml
@@ -529,7 +529,10 @@ screens:
         n_bits: PROF:DASEL:440:N_OF_BITS
         n_col: PROF:DASEL:440:Image:ArraySize1_RBV
         n_row: PROF:DASEL:440:Image:ArraySize0_RBV
+        ref_rate: PROF:DASEL:440:ArrayRate_RBV
+        ref_rate_vme: PROF:DASEL:440:FRAME_RATE
         resolution: PROF:DASEL:440:RESOLUTION
+        sys_type: PROF:DASEL:440:SYS_TYPE
       control_name: PROF:DASEL:440
     metadata:
       area: DASEL
@@ -544,7 +547,10 @@ screens:
         n_bits: PROF:DASEL:655:N_OF_BITS
         n_col: PROF:DASEL:655:Image:ArraySize1_RBV
         n_row: PROF:DASEL:655:Image:ArraySize0_RBV
+        ref_rate: PROF:DASEL:655:ArrayRate_RBV
+        ref_rate_vme: PROF:DASEL:655:FRAME_RATE
         resolution: PROF:DASEL:655:RESOLUTION
+        sys_type: PROF:DASEL:655:SYS_TYPE
       control_name: PROF:DASEL:655
     metadata:
       area: DASEL
@@ -559,7 +565,10 @@ screens:
         n_bits: PROF:DASEL:818:N_OF_BITS
         n_col: PROF:DASEL:818:Image:ArraySize1_RBV
         n_row: PROF:DASEL:818:Image:ArraySize0_RBV
+        ref_rate: PROF:DASEL:818:ArrayRate_RBV
+        ref_rate_vme: PROF:DASEL:818:FRAME_RATE
         resolution: PROF:DASEL:818:RESOLUTION
+        sys_type: PROF:DASEL:818:SYS_TYPE
       control_name: PROF:DASEL:818
     metadata:
       area: DASEL

--- a/lcls_tools/common/devices/yaml/DIAG0.yaml
+++ b/lcls_tools/common/devices/yaml/DIAG0.yaml
@@ -493,7 +493,10 @@ screens:
         n_bits: OTRS:DIAG0:420:N_OF_BITS
         n_col: OTRS:DIAG0:420:Image:ArraySize1_RBV
         n_row: OTRS:DIAG0:420:Image:ArraySize0_RBV
+        ref_rate: OTRS:DIAG0:420:ArrayRate_RBV
+        ref_rate_vme: OTRS:DIAG0:420:FRAME_RATE
         resolution: OTRS:DIAG0:420:RESOLUTION
+        sys_type: OTRS:DIAG0:420:SYS_TYPE
       control_name: OTRS:DIAG0:420
     metadata:
       area: DIAG0
@@ -508,7 +511,10 @@ screens:
         n_bits: OTRS:DIAG0:525:N_OF_BITS
         n_col: OTRS:DIAG0:525:Image:ArraySize1_RBV
         n_row: OTRS:DIAG0:525:Image:ArraySize0_RBV
+        ref_rate: OTRS:DIAG0:525:ArrayRate_RBV
+        ref_rate_vme: OTRS:DIAG0:525:FRAME_RATE
         resolution: OTRS:DIAG0:525:RESOLUTION
+        sys_type: OTRS:DIAG0:525:SYS_TYPE
       control_name: OTRS:DIAG0:525
     metadata:
       area: DIAG0

--- a/lcls_tools/common/devices/yaml/DL1.yaml
+++ b/lcls_tools/common/devices/yaml/DL1.yaml
@@ -614,7 +614,10 @@ screens:
         n_bits: OTRS:IN20:571:N_OF_BITS
         n_col: OTRS:IN20:571:Image:ArraySize1_RBV
         n_row: OTRS:IN20:571:Image:ArraySize0_RBV
+        ref_rate: OTRS:IN20:571:ArrayRate_RBV
+        ref_rate_vme: OTRS:IN20:571:FRAME_RATE
         resolution: OTRS:IN20:571:RESOLUTION
+        sys_type: OTRS:IN20:571:SYS_TYPE
       control_name: OTRS:IN20:571
     metadata:
       area: DL1
@@ -635,7 +638,9 @@ screens:
         n_bits: OTRS:IN20:621:N_OF_BITS
         n_col: OTRS:IN20:621:N_OF_COL
         n_row: OTRS:IN20:621:N_OF_ROW
+        ref_rate_vme: OTRS:IN20:621:FRAME_RATE
         resolution: OTRS:IN20:621:RESOLUTION
+        sys_type: OTRS:IN20:621:SYS_TYPE
       control_name: OTRS:IN20:621
     metadata:
       area: DL1
@@ -656,7 +661,9 @@ screens:
         n_bits: OTRS:IN20:711:N_OF_BITS
         n_col: OTRS:IN20:711:N_OF_COL
         n_row: OTRS:IN20:711:N_OF_ROW
+        ref_rate_vme: OTRS:IN20:711:FRAME_RATE
         resolution: OTRS:IN20:711:RESOLUTION
+        sys_type: OTRS:IN20:711:SYS_TYPE
       control_name: OTRS:IN20:711
     metadata:
       area: DL1
@@ -676,7 +683,10 @@ screens:
         n_bits: OTRS:IN20:465:N_OF_BITS
         n_col: OTRS:IN20:465:Image:ArraySize1_RBV
         n_row: OTRS:IN20:465:Image:ArraySize0_RBV
+        ref_rate: OTRS:IN20:465:ArrayRate_RBV
+        ref_rate_vme: OTRS:IN20:465:FRAME_RATE
         resolution: OTRS:IN20:465:RESOLUTION
+        sys_type: OTRS:IN20:465:SYS_TYPE
       control_name: OTRS:IN20:465
     metadata:
       area: DL1
@@ -697,7 +707,10 @@ screens:
         n_bits: OTRS:IN20:471:N_OF_BITS
         n_col: OTRS:IN20:471:Image:ArraySize1_RBV
         n_row: OTRS:IN20:471:Image:ArraySize0_RBV
+        ref_rate: OTRS:IN20:471:ArrayRate_RBV
+        ref_rate_vme: OTRS:IN20:471:FRAME_RATE
         resolution: OTRS:IN20:471:RESOLUTION
+        sys_type: OTRS:IN20:471:SYS_TYPE
       control_name: OTRS:IN20:471
     metadata:
       area: DL1

--- a/lcls_tools/common/devices/yaml/DMPH.yaml
+++ b/lcls_tools/common/devices/yaml/DMPH.yaml
@@ -291,7 +291,10 @@ screens:
         n_bits: OTRS:DMPH:695:N_OF_BITS
         n_col: OTRS:DMPH:695:Image:ArraySize1_RBV
         n_row: OTRS:DMPH:695:Image:ArraySize0_RBV
+        ref_rate: OTRS:DMPH:695:ArrayRate_RBV
+        ref_rate_vme: OTRS:DMPH:695:FRAME_RATE
         resolution: OTRS:DMPH:695:RESOLUTION
+        sys_type: OTRS:DMPH:695:SYS_TYPE
       control_name: OTRS:DMPH:695
     metadata:
       area: DMPH

--- a/lcls_tools/common/devices/yaml/DMPS.yaml
+++ b/lcls_tools/common/devices/yaml/DMPS.yaml
@@ -297,7 +297,10 @@ screens:
         n_bits: OTRS:DMPS:695:N_OF_BITS
         n_col: OTRS:DMPS:695:Image:ArraySize1_RBV
         n_row: OTRS:DMPS:695:Image:ArraySize0_RBV
+        ref_rate: OTRS:DMPS:695:ArrayRate_RBV
+        ref_rate_vme: OTRS:DMPS:695:FRAME_RATE
         resolution: OTRS:DMPS:695:RESOLUTION
+        sys_type: OTRS:DMPS:695:SYS_TYPE
       control_name: OTRS:DMPS:695
     metadata:
       area: DMPS

--- a/lcls_tools/common/devices/yaml/DOG.yaml
+++ b/lcls_tools/common/devices/yaml/DOG.yaml
@@ -1109,7 +1109,10 @@ screens:
         n_bits: PROF:DOG:195:N_OF_BITS
         n_col: PROF:DOG:195:Image:ArraySize1_RBV
         n_row: PROF:DOG:195:Image:ArraySize0_RBV
+        ref_rate: PROF:DOG:195:ArrayRate_RBV
+        ref_rate_vme: PROF:DOG:195:FRAME_RATE
         resolution: PROF:DOG:195:RESOLUTION
+        sys_type: PROF:DOG:195:SYS_TYPE
       control_name: PROF:DOG:195
     metadata:
       area: DOG

--- a/lcls_tools/common/devices/yaml/GSPEC.yaml
+++ b/lcls_tools/common/devices/yaml/GSPEC.yaml
@@ -133,7 +133,9 @@ screens:
         n_bits: YAGS:IN20:841:N_OF_BITS
         n_col: YAGS:IN20:841:N_OF_COL
         n_row: YAGS:IN20:841:N_OF_ROW
+        ref_rate_vme: YAGS:IN20:841:FRAME_RATE
         resolution: YAGS:IN20:841:RESOLUTION
+        sys_type: YAGS:IN20:841:SYS_TYPE
       control_name: YAGS:IN20:841
     metadata:
       area: GSPEC

--- a/lcls_tools/common/devices/yaml/GUN.yaml
+++ b/lcls_tools/common/devices/yaml/GUN.yaml
@@ -207,6 +207,7 @@ screens:
         n_bits: YAGS:IN20:211:N_OF_BITS
         n_col: YAGS:IN20:211:N_OF_COL
         n_row: YAGS:IN20:211:N_OF_ROW
+        ref_rate_vme: YAGS:IN20:211:FRAME_RATE
         resolution: YAGS:IN20:211:RESOLUTION
       control_name: YAGS:IN20:211
     metadata:

--- a/lcls_tools/common/devices/yaml/HTR.yaml
+++ b/lcls_tools/common/devices/yaml/HTR.yaml
@@ -761,7 +761,10 @@ screens:
         n_bits: OTRS:HTR:330:N_OF_BITS
         n_col: OTRS:HTR:330:Image:ArraySize1_RBV
         n_row: OTRS:HTR:330:Image:ArraySize0_RBV
+        ref_rate: OTRS:HTR:330:ArrayRate_RBV
+        ref_rate_vme: OTRS:HTR:330:FRAME_RATE
         resolution: OTRS:HTR:330:RESOLUTION
+        sys_type: OTRS:HTR:330:SYS_TYPE
       control_name: OTRS:HTR:330
     metadata:
       area: HTR
@@ -784,7 +787,10 @@ screens:
         n_bits: YAGS:HTR:625:N_OF_BITS
         n_col: YAGS:HTR:625:Image:ArraySize1_RBV
         n_row: YAGS:HTR:625:Image:ArraySize0_RBV
+        ref_rate: YAGS:HTR:625:ArrayRate_RBV
+        ref_rate_vme: YAGS:HTR:625:FRAME_RATE
         resolution: YAGS:HTR:625:RESOLUTION
+        sys_type: YAGS:HTR:625:SYS_TYPE
       control_name: YAGS:HTR:625
     metadata:
       area: HTR
@@ -807,7 +813,10 @@ screens:
         n_bits: YAGS:HTR:675:N_OF_BITS
         n_col: YAGS:HTR:675:Image:ArraySize1_RBV
         n_row: YAGS:HTR:675:Image:ArraySize0_RBV
+        ref_rate: YAGS:HTR:675:ArrayRate_RBV
+        ref_rate_vme: YAGS:HTR:675:FRAME_RATE
         resolution: YAGS:HTR:675:RESOLUTION
+        sys_type: YAGS:HTR:675:SYS_TYPE
       control_name: YAGS:HTR:675
     metadata:
       area: HTR

--- a/lcls_tools/common/devices/yaml/L0.yaml
+++ b/lcls_tools/common/devices/yaml/L0.yaml
@@ -271,7 +271,10 @@ screens:
         n_bits: YAGS:IN20:241:N_OF_BITS
         n_col: YAGS:IN20:241:Image:ArraySize1_RBV
         n_row: YAGS:IN20:241:Image:ArraySize0_RBV
+        ref_rate: YAGS:IN20:241:ArrayRate_RBV
+        ref_rate_vme: YAGS:IN20:241:FRAME_RATE
         resolution: YAGS:IN20:241:RESOLUTION
+        sys_type: YAGS:IN20:241:SYS_TYPE
       control_name: YAGS:IN20:241
     metadata:
       area: L0
@@ -292,7 +295,9 @@ screens:
         n_bits: YAGS:IN20:351:N_OF_BITS
         n_col: YAGS:IN20:351:N_OF_COL
         n_row: YAGS:IN20:351:N_OF_ROW
+        ref_rate_vme: YAGS:IN20:351:FRAME_RATE
         resolution: YAGS:IN20:351:RESOLUTION
+        sys_type: YAGS:IN20:351:SYS_TYPE
       control_name: YAGS:IN20:351
     metadata:
       area: L0

--- a/lcls_tools/common/devices/yaml/LTUH.yaml
+++ b/lcls_tools/common/devices/yaml/LTUH.yaml
@@ -2220,7 +2220,9 @@ screens:
       type: PROF
   OTR33:
     controls_information:
-      PVs: {}
+      PVs:
+        ref_rate_vme: OTRS:LTUH:745:FRAME_RATE
+        sys_type: OTRS:LTUH:745:SYS_TYPE
       control_name: OTRS:LTUH:745
     metadata:
       area: LTUH
@@ -2239,7 +2241,10 @@ screens:
         n_bits: YAGS:LTUH:743:N_OF_BITS
         n_col: YAGS:LTUH:743:Image:ArraySize1_RBV
         n_row: YAGS:LTUH:743:Image:ArraySize0_RBV
+        ref_rate: YAGS:LTUH:743:ArrayRate_RBV
+        ref_rate_vme: YAGS:LTUH:743:FRAME_RATE
         resolution: YAGS:LTUH:743:RESOLUTION
+        sys_type: YAGS:LTUH:743:SYS_TYPE
       control_name: YAGS:LTUH:743
     metadata:
       area: LTUH

--- a/lcls_tools/common/devices/yaml/SPEC.yaml
+++ b/lcls_tools/common/devices/yaml/SPEC.yaml
@@ -160,7 +160,9 @@ screens:
         n_bits: YAGS:IN20:921:N_OF_BITS
         n_col: YAGS:IN20:921:N_OF_COL
         n_row: YAGS:IN20:921:N_OF_ROW
+        ref_rate_vme: YAGS:IN20:921:FRAME_RATE
         resolution: YAGS:IN20:921:RESOLUTION
+        sys_type: YAGS:IN20:921:SYS_TYPE
       control_name: YAGS:IN20:921
     metadata:
       area: SPEC
@@ -175,7 +177,9 @@ screens:
         n_bits: YAGS:IN20:995:N_OF_BITS
         n_col: YAGS:IN20:995:N_OF_COL
         n_row: YAGS:IN20:995:N_OF_ROW
+        ref_rate_vme: YAGS:IN20:995:FRAME_RATE
         resolution: YAGS:IN20:995:RESOLUTION
+        sys_type: YAGS:IN20:995:SYS_TYPE
       control_name: YAGS:IN20:995
     metadata:
       area: SPEC

--- a/lcls_tools/common/devices/yaml/UNDS.yaml
+++ b/lcls_tools/common/devices/yaml/UNDS.yaml
@@ -2015,11 +2015,14 @@ screens:
   BOD10:
     controls_information:
       PVs:
-        image: YAGS:UNDS:3575:IMAGE
+        image: YAGS:UNDS:3575:Image:ArrayData
         n_bits: YAGS:UNDS:3575:N_OF_BITS
         n_col: YAGS:UNDS:3575:N_OF_COL
         n_row: YAGS:UNDS:3575:N_OF_ROW
+        ref_rate: YAGS:UNDS:3575:ArrayRate_RBV
+        ref_rate_vme: YAGS:UNDS:3575:FRAME_RATE
         resolution: YAGS:UNDS:3575:RESOLUTION
+        sys_type: YAGS:UNDS:3575:SYS_TYPE
       control_name: YAGS:UNDS:3575
     metadata:
       area: UNDS
@@ -2035,11 +2038,14 @@ screens:
   BOD12:
     controls_information:
       PVs:
-        image: YAGS:UNDS:3795:IMAGE
+        image: YAGS:UNDS:3795:Image:ArrayData
         n_bits: YAGS:UNDS:3795:N_OF_BITS
         n_col: YAGS:UNDS:3795:N_OF_COL
         n_row: YAGS:UNDS:3795:N_OF_ROW
+        ref_rate: YAGS:UNDS:3795:ArrayRate_RBV
+        ref_rate_vme: YAGS:UNDS:3795:FRAME_RATE
         resolution: YAGS:UNDS:3795:RESOLUTION
+        sys_type: YAGS:UNDS:3795:SYS_TYPE
       control_name: YAGS:UNDS:3795
     metadata:
       area: UNDS

--- a/lcls_tools/common/devices/yaml/generate.py
+++ b/lcls_tools/common/devices/yaml/generate.py
@@ -313,6 +313,10 @@ class YAMLGenerator:
             "N_OF_COL": "n_col",
             "N_OF_ROW": "n_row",
             "N_OF_BITS": "n_bits",
+            "SYS_TYPE": "sys_type",
+            "FRAME_RATE": "ref_rate_vme",
+            "ArrayRate_RBV": "ref_rate"
+
         }
         # should be structured {MAD-NAME : {field_name : value, field_name_2 : value}, ... }
         additional_metadata_data = get_screen_metadata()


### PR DESCRIPTION
Hi, this pull request is to add refresh rate PVs and a getter method to the screens device class.
Some info that needs to be known beforehand is that many cameras have two refresh rate PVs, but only one is used. In order to determine what PV to use you need to know whether the IOC the camera runs on is a VME or LinuxRT. So I added the PV that tells you that information as well. 