### PR TITLE
Specify shell for running tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,6 +28,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
+      shell: bash
       run: |
         eval `ssh-agent -s`
         ssh-add - <<< '${{ secrets.MEME_KEY }}'
@@ -35,10 +36,12 @@ jobs:
         pip install flake8
         pip install ".[meme-ssh]"
     - name: Lint with flake8
+      shell: bash
       run: |
         # stop the build if there are Python syntax errors or undefined names
         flake8 .
     - name: Test with unittest
+      shell: bash
       run: |
         echo -e '## Test results\n\n```' >> "$GITHUB_STEP_SUMMARY"
         python -m unittest discover -s tests -v 2>&1 | tee -a "$GITHUB_STEP_SUMMARY"
@@ -61,15 +64,18 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
+        shell: bash
         run: |
           python -m pip install --upgrade pip
           pip install flake8
           pip install .
       - name: Lint with flake8
+        shell: bash
         run: |
           # stop the build if there are Python syntax errors or undefined names
           flake8 .
       - name: Test with unittest
+        shell: bash
         run: |
           echo -e '## Test results\n\n```' >> "$GITHUB_STEP_SUMMARY"
           python -m unittest discover -s tests -v 2>&1 | tee -a "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
This addresses a bug in the testing workflow where tests fail but the GHA show as passed, see here:
- [example 1](https://github.com/slaclab/lcls-tools/actions/runs/13459888949/job/37612415062)
- [example 2](https://github.com/slaclab/lcls-tools/actions/runs/13478922929/job/37661632846)

This is due to how the GitHub step summary is set up to print the output, where the “>>” operator doesn’t play nice with default shells. This PR sets the shell explicitly and resolves this issue.