### PR TITLE
Add function to load all YAML metadata files for a specified beampath

### DIFF
--- a/lcls_tools/common/devices/reader.py
+++ b/lcls_tools/common/devices/reader.py
@@ -21,7 +21,7 @@ def _find_yaml_file(
     if area:
         filename = area + ".yaml"
     if beampath:
-        filename = "beam_paths.yaml"
+        filename = "beampaths.yaml"
 
     path = os.path.join(DEFAULT_YAML_LOCATION, filename)
     if os.path.isfile(path):
@@ -228,3 +228,23 @@ def create_beampath(beampath: str = None) -> Union[None, Beampath]:
             ". Please try a different beampath.",
         )
         return None
+
+
+def load_full_beampath(beampath: str):
+    beampaths_location = _find_yaml_file(beampath=beampath)
+    with open(beampaths_location, "r") as file:
+        beampaths = yaml.safe_load(file)
+
+    areas_nested = beampaths.get(beampath)
+    if areas_nested is None:
+        raise ValueError(f"Beampath '{beampath}' not found in {beampaths_location}")
+
+    area_names = list(_flatten(areas_nested))
+    beampath_data = {}
+
+    for area in area_names:
+        device_data = _device_data(area=area)
+        if device_data is not None:
+            beampath_data[area] = device_data
+
+    return beampath_data


### PR DESCRIPTION
This PR adds the `load_full_beampath` function, which loads all YAML metadata files associated with a given beampath. The function:

- Locates and parses the top-level `beampaths.yaml` file.
- Flattens the nested area structure for the specified beampath.
- Loads device metadata for each area using `_device_data`.
- Returns a dictionary mapping area names to their corresponding metadata.
- Raises a `ValueError` if the specified beampath is not defined in the `beampaths.yaml` file.
