### PR TITLE
 Add function to load all YAML metadata files for a specified beampath

### DIFF
--- a/lcls_tools/common/devices/reader.py
+++ b/lcls_tools/common/devices/reader.py
@@ -243,6 +243,8 @@ def load_full_beampath(beampath: str):
     beampath_data = {}
 
     for area in area_names:
-        beampath_data[area] = _device_data(area=area)
+        device_data = _device_data(area=area)
+        if device_data is not None:
+            beampath_data[area] = device_data
 
     return beampath_data


### PR DESCRIPTION
This PR adds the `load_full_beampath` function, which loads all YAML metadata files associated with a given beampath. The function:

- Locates and parses the top-level `beampaths.yaml` file.
- Flattens the nested area structure for the specified beampath.
- Loads device metadata for each area using `_device_data`.
- Returns a dictionary mapping area names to their corresponding metadata.
- Raises a `ValueError` if the specified beampath is not defined in the `beampaths.yaml` file.