### PR TITLE
Extend Area model to support BPMs and LBLMs

### DIFF
--- a/lcls_tools/common/devices/area.py
+++ b/lcls_tools/common/devices/area.py
@@ -249,7 +249,7 @@ class Area(lcls_tools.common.BaseModel):
         self,
         wire_name: str = None,
     ) -> bool:
-        return screen_name in self.wires
+        return wire_name in self.wires
 
     def does_bpm_exist(
         self,

--- a/lcls_tools/common/devices/area.py
+++ b/lcls_tools/common/devices/area.py
@@ -107,46 +107,45 @@ class Area(lcls_tools.common.BaseModel):
         mode="before",
     )
     def validate_magnets(cls, v: Dict[str, Any]):
-        if v:
-            # Unpack the magnet data from yaml into MagnetCollection
-            # before creating the magnet_collection
-            return MagnetCollection(**{"magnets": {**v}})
+        if not v:
+            return None
+        return MagnetCollection(magnets=v)
 
     @field_validator(
         "screen_collection",
         mode="before",
     )
     def validate_screens(cls, v: Dict[str, Any]):
-        if v:
-            # Unpack the screens data from yaml into ScreenCollection
-            return ScreenCollection(**{"screens": {**v}})
+        if not v:
+            return None
+        return ScreenCollection(screens=v)
 
     @field_validator(
         "wire_collection",
         mode="before",
     )
     def validate_wires(cls, v: Dict[str, Any]):
-        if v:
-            # Unpack the wires data from yaml into WireCollection
-            return WireCollection(**{"wires": {**v}})
+        if not v:
+            return None
+        return WireCollection(wires=v)
 
     @field_validator(
         "bpm_collection",
         mode="before",
     )
     def validate_bpms(cls, v: Dict[str, Any]):
-        if v:
-            # Unpack the bpms data from yaml into BPMCollection
-            return BPMCollection(**{"bpms": {**v}})
+        if not v:
+            return None
+        return BPMCollection(bpms=v)
 
     @field_validator(
         "lblm_collection",
         mode="before",
     )
     def validate_lblms(cls, v: Dict[str, Any]):
-        if v:
-            # Unpack the lblms data from yaml into LBLMCollection
-            return LBLMCollection(**{"lblms": {**v}})
+        if not v:
+            return None
+        return LBLMCollection(lblms=v)
 
     @property
     def magnets(

--- a/lcls_tools/common/devices/area.py
+++ b/lcls_tools/common/devices/area.py
@@ -19,6 +19,14 @@ from lcls_tools.common.devices.wire import (
     Wire,
     WireCollection,
 )
+from lcls_tools.common.devices.bpm import (
+    BPM,
+    BPMCollection,
+)
+from lcls_tools.common.devices.lblm import (
+    LBLM,
+    LBLMCollection,
+)
 
 from pydantic import SerializeAsAny, Field, field_validator
 
@@ -63,6 +71,24 @@ class Area(lcls_tools.common.BaseModel):
         alias="wires",
         default=None,
     )
+    bpm_collection: Optional[
+        Union[
+            SerializeAsAny[BPMCollection],
+            None,
+        ]
+    ] = Field(
+        alias="bpms",
+        default=None,
+    )
+    lblm_collection: Optional[
+        Union[
+            SerializeAsAny[LBLMCollection],
+            None,
+        ]
+    ] = Field(
+        alias="lblms",
+        default=None,
+    )
 
     def __init__(
         self,
@@ -103,6 +129,24 @@ class Area(lcls_tools.common.BaseModel):
         if v:
             # Unpack the wires data from yaml into WireCollection
             return WireCollection(**{"wires": {**v}})
+
+    @field_validator(
+        "bpm_collection",
+        mode="before",
+    )
+    def validate_bpms(cls, v: Dict[str, Any]):
+        if v:
+            # Unpack the bpms data from yaml into BPMCollection
+            return BPMCollection(**{"bpms": {**v}})
+
+    @field_validator(
+        "lblm_collection",
+        mode="before",
+    )
+    def validate_lblms(cls, v: Dict[str, Any]):
+        if v:
+            # Unpack the lblms data from yaml into LBLMCollection
+            return LBLMCollection(**{"lblms": {**v}})
 
     @property
     def magnets(
@@ -155,6 +199,40 @@ class Area(lcls_tools.common.BaseModel):
             print("Area does not contain wires.")
             return None
 
+    @property
+    def bpms(
+        self,
+    ) -> Union[
+        Dict[str, BPM],
+        None,
+    ]:
+        """
+        A Dict[str, BPM] for this area, where the dict keys are bpm names
+        If no bpms exist for this area, this property is None
+        """
+        if self.bpm_collection:
+            return self.bpm_collection.bpms
+        else:
+            print("Area does not contain bpms.")
+            return None
+
+    @property
+    def lblms(
+        self,
+    ) -> Union[
+        Dict[str, LBLM],
+        None,
+    ]:
+        """
+        A Dict[str, LBLM] for this area, where the dict keys are lblm names
+        If no lblms exist for this area, this property is None
+        """
+        if self.lblm_collection:
+            return self.lblm_collection.lblms
+        else:
+            print("Area does not contain lblms.")
+            return None
+
     def does_magnet_exist(
         self,
         magnet_name: str = None,
@@ -166,3 +244,21 @@ class Area(lcls_tools.common.BaseModel):
         screen_name: str = None,
     ) -> bool:
         return screen_name in self.screens
+
+    def does_wire_exist(
+        self,
+        wire_name: str = None,
+    ) -> bool:
+        return screen_name in self.wires
+
+    def does_bpm_exist(
+        self,
+        bpm_name: str = None,
+    ) -> bool:
+        return bpm_name in self.bpms
+
+    def does_lblm_exist(
+        self,
+        lblm_name: str = None,
+    ) -> bool:
+        return lblm_name in self.lblms


### PR DESCRIPTION
This PR extends the `Area` model to support `BPM` and `LBLM` devices which were previously unsupported.  Attempting to create and `Area` containing these devices would result in Pydantic validation errors due to missing model fields.

The changes introduce:

- A `bpm_collection` field (aliased from `bpms`) using the `BPMCollection` class
- A `lblm_collection` field (aliased from `lblms`) using the `LBLMCollection` class
- Field validators to properly initialize these collections from YAML dictionaries

With this update, BPM and LBLM devices are now handled consistently alongside existing device types such as magnets, wires, and screens.