### PR TITLE
Addresses #274: Making select PV fields Optional

### DIFF
--- a/lcls_tools/common/devices/bpm.py
+++ b/lcls_tools/common/devices/bpm.py
@@ -21,9 +21,9 @@ EPICS_ERROR_MESSAGE = "Unable to connect to EPICS."
 
 
 class BPMPVSet(PVSet):
-    x: PV
-    y: PV
-    tmit: PV
+    x: Optional[PV] = None
+    y: Optional[PV] = None
+    tmit: Optional[PV] = None
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
@@ -57,32 +57,56 @@ class BPM(Device):
 
     @property
     def x(self):
-        """Get TMIT value"""
-        return self.controls_information.PVs.x.get()
+        """Get X value"""
+        pv = self.controls_information.PVs.x
+        if pv is None:
+            raise AttributeError("X PV is not defined for this device")
+        return pv.get()
 
     def x_buffer(self, buffer):
-        """Retrieve TMIT signal data from timing buffer"""
-        return buffer.get_buffer_data(self.controls_information.PVs.x)
+        """Retrieve X signal data from timing buffer"""
+        pv = self.controls_information.PVs.x
+        if pv is None:
+            raise AttributeError("X PV is not defined for this device")
+        data = buffer.get_data_buffer(self.controls_information.PVs.x.pvname)
+        if data is None:
+            raise BufferError("No data found in buffer for X PV")
+        return data
 
     @property
     def y(self):
-        """Get TMIT value"""
-        return self.controls_information.PVs.y.get()
+        """Get Y value"""
+        pv = self.controls_information.PVs.y
+        if pv is None:
+            raise AttributeError("Y PV is not defined for this device")
+        return pv.get()
 
     def y_buffer(self, buffer):
-        """Retrieve TMIT signal data from timing buffer"""
-        return buffer.get_buffer_data(self.controls_information.PVs.y)
+        """Retrieve Y signal data from timing buffer"""
+        pv = self.controls_information.PVs.y
+        if pv is None:
+            raise AttributeError("Y PV is not defined for this device")
+        data = buffer.get_data_buffer(self.controls_information.PVs.y.pvname)
+        if data is None:
+            raise BufferError("No data found in buffer for Y PV")
+        return data
 
     @property
     def tmit(self):
         """Get TMIT value"""
-        return self.controls_information.PVs.tmit.get()
+        pv = self.controls_information.PVs.tmit
+        if pv is None:
+            raise AttributeError("TMIT PV is not defined for this device")
+        return pv.get()
 
     def tmit_buffer(self, buffer):
         """Retrieve TMIT signal data from timing buffer"""
+        pv = self.controls_information.PVs.tmit
+        if pv is None:
+            raise AttributeError("TMIT PV is not defined for this device")
         data = buffer.get_data_buffer(self.controls_information.PVs.tmit.pvname)
         if data is None:
-            raise BufferError("No data in buffer or PV not found")
+            raise BufferError("No data found in buffer for TMIT PV")
         return data
 
 

--- a/lcls_tools/common/devices/bpm.py
+++ b/lcls_tools/common/devices/bpm.py
@@ -68,6 +68,7 @@ class BPM(Device):
         pv = self.controls_information.PVs.x
         if pv is None:
             raise AttributeError("X PV is not defined for this device")
+        # get_data_buffer requires PV name as string, not EPICS PV object
         data = buffer.get_data_buffer(self.controls_information.PVs.x.pvname)
         if data is None:
             raise BufferError("No data found in buffer for X PV")
@@ -86,6 +87,7 @@ class BPM(Device):
         pv = self.controls_information.PVs.y
         if pv is None:
             raise AttributeError("Y PV is not defined for this device")
+        # get_data_buffer requires PV name as string, not EPICS PV object
         data = buffer.get_data_buffer(self.controls_information.PVs.y.pvname)
         if data is None:
             raise BufferError("No data found in buffer for Y PV")
@@ -104,6 +106,7 @@ class BPM(Device):
         pv = self.controls_information.PVs.tmit
         if pv is None:
             raise AttributeError("TMIT PV is not defined for this device")
+        # get_data_buffer requires PV name as string, not EPICS PV object
         data = buffer.get_data_buffer(self.controls_information.PVs.tmit.pvname)
         if data is None:
             raise BufferError("No data found in buffer for TMIT PV")

--- a/lcls_tools/common/devices/lblm.py
+++ b/lcls_tools/common/devices/lblm.py
@@ -36,10 +36,10 @@ class IntegerModel(BaseModel):
 
 
 class LBLMPVSet(PVSet):
-    gated_integral: PV
-    i0_loss: PV
-    gain: PV
-    bypass: PV
+    gated_integral: Optional[PV] = None
+    i0_loss: Optional[PV] = None
+    gain: Optional[PV] = None
+    bypass: Optional[PV] = None
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
@@ -79,17 +79,48 @@ class LBLM(Device):
     @property
     def i0_loss(self):
         """Get I0 Loss value"""
-        return self.controls_information.PVs.i0_loss.get()
+        pv = self.controls_information.PVs.i0_loss
+        if pv is None:
+            raise AttributeError("I0_LOSS PV is not defined for this device")
+        return pv.get()
+
+    def i0_loss_buffer(self, buffer):
+        """Retrieve I0 Loss data from timing buffer"""
+        pv = self.controls_information.PVs.i0_loss
+        if pv is None:
+            raise AttributeError("I0_LOSS PV is not defined for this device")
+        data = buffer.get_data_buffer(self.controls_information.PVs.i0_loss.pvname)
+        if data is None:
+            raise BufferError("No data in buffer or PV not found")
+        return data
 
     @property
     def gated_integral(self):
         """Get Gated Integral value"""
-        return self.controls_information.PVs.gated_integral.get()
+        pv = self.controls_information.PVs.gated_integral
+        if pv is None:
+            raise AttributeError("GATED_INTEGRAL PV is not defined for this device")
+        return pv.get()
+
+    def gated_integral_buffer(self, buffer):
+        """Get Gated Integral data from timing buffer"""
+        pv = self.controls_information.PVs.gated_integral
+        if pv is None:
+            raise BufferError("GATED_INTEGRAL PV is not defined for this device")
+        data = buffer.get_data_buffer(
+            self.controls_information.PVs.gated_integral.pvname
+        )
+        if data is None:
+            raise BufferError("No data in buffer or PV not found")
+        return data
 
     @property
     def gain(self):
         """Get gain value"""
-        return self.controls_information.PVs.gain.get()
+        pv = self.controls_information.PVs.gain
+        if pv is None:
+            raise AttributeError("GAIN PV is not defined for this device")
+        return pv.get()
 
     @gain.setter
     def gain(self, val: float) -> None:
@@ -102,7 +133,10 @@ class LBLM(Device):
     @property
     def bypass(self):
         """Get bypass state"""
-        return self.controls_information.PVs.bypass.get()
+        pv = self.controls_information.PVs.bypass
+        if pv is None:
+            raise AttributeError("BYPASS PV is not defined for this device")
+        return pv.get()
 
     @bypass.setter
     def bypass(self, val: bool) -> None:
@@ -111,22 +145,6 @@ class LBLM(Device):
             self.controls_information.PVs.bypass.put(value=val)
         except ValidationError as e:
             print("Bypass must be a boolean:", e)
-
-    def i0_loss_buffer(self, buffer):
-        """Retrieve I0 Loss data from timing buffer"""
-        data = buffer.get_data_buffer(self.controls_information.PVs.i0_loss.pvname)
-        if data is None:
-            raise BufferError("No data in buffer or PV not found")
-        return data
-
-    def gated_integral_buffer(self, buffer):
-        """Get Gated Integral data from timing buffer"""
-        data = buffer.get_data_buffer(
-            self.controls_information.PVs.gated_integral.pvname
-        )
-        if data is None:
-            raise BufferError("No data in buffer or PV not found")
-        return data
 
 
 class LBLMCollection(BaseModel):

--- a/lcls_tools/common/devices/lblm.py
+++ b/lcls_tools/common/devices/lblm.py
@@ -71,7 +71,10 @@ class LBLM(Device):
 
     def fast_buffer(self, buffer):
         """Retrieve fast signal data from timing buffer"""
-        data = buffer.get_data_buffer(f"{self.controls_information.control_name}:FAST")
+        # :FAST PV confusingly does not exist outside of buffer
+        # get_data_buffer requires PV name as string, not EPICS PV object
+        pv = f"{self.controls_information.control_name}:FAST"
+        data = buffer.get_data_buffer(pv)
         if data is None:
             raise BufferError("No data in buffer or PV not found")
         return data
@@ -89,6 +92,7 @@ class LBLM(Device):
         pv = self.controls_information.PVs.i0_loss
         if pv is None:
             raise AttributeError("I0_LOSS PV is not defined for this device")
+        # get_data_buffer requires PV name as string, not EPICS PV object
         data = buffer.get_data_buffer(self.controls_information.PVs.i0_loss.pvname)
         if data is None:
             raise BufferError("No data in buffer or PV not found")
@@ -107,6 +111,7 @@ class LBLM(Device):
         pv = self.controls_information.PVs.gated_integral
         if pv is None:
             raise BufferError("GATED_INTEGRAL PV is not defined for this device")
+        # get_data_buffer requires PV name as string, not EPICS PV object
         data = buffer.get_data_buffer(
             self.controls_information.PVs.gated_integral.pvname
         )

--- a/lcls_tools/common/devices/wire.py
+++ b/lcls_tools/common/devices/wire.py
@@ -178,7 +178,13 @@ class Wire(Device):
         return self.controls_information.PVs.motor_rbv.get()
 
     def position_buffer(self, buffer):
-        return buffer.get_data_buffer(f"{self.controls_information.control_name}:POSN")
+        # :POSN PV confusingly does not exist outside of buffer
+        # get_data_buffer requires PV name as string, not EPICS PV object
+        pv = f"{self.controls_information.control_name}:POSN"
+        data = buffer.get_data_buffer(pv)
+        if data is None:
+            raise BufferError("No data in buffer or PV not found")
+        return data
 
     def retract(self):
         """Retracts the wire scanner"""

--- a/lcls_tools/common/devices/wire.py
+++ b/lcls_tools/common/devices/wire.py
@@ -71,7 +71,7 @@ class WirePVSet(PVSet):
     speed_max: PV
     speed_min: PV
     start_scan: PV
-    temperature: PV
+    temperature: Optional[PV] = None
     timeout: PV
     use_u_wire: PV
     use_x_wire: PV
@@ -258,7 +258,10 @@ class Wire(Device):
     @property
     def temperature(self):
         """Returns RTD temperature"""
-        return self.controls_information.PVs.temperature.get()
+        pv = self.controls_information.PVs.temperature
+        if pv is None:
+            raise AttributeError("TEMPERATURE PV is not defined for this device")
+        return pv.get()
 
     @property
     def timeout(self):


### PR DESCRIPTION
This PR updates device models (`BPM`, `LBLM`, `Wire`) to make some PV fields optional by default. Previously, if any expected PV was missing from the YAML configuration, `lcls_tools.common.devices.reader` would raise a Pydantic validation error during instantiation.

Changes include:

- Defining all `BPM` and `LBLM` PV fields as `Optional[PV] = None`
- Defining one `Wire` PV field as `Optional[PV] = None`
- Ensuring devices can be safely created even when certain PVs are omitted from the YAML by refactoring Optional PV attributes and methods
- Maintaining existing device loading patterns
- Refactoring buffer methods to raise `AttributeError` or `BufferError` depending on failure methods 

This improves robustness when dealing with device definitions and ensures more flexible YAML configurations across different areas and machine types.