### PR TITLE
Generate Quality of Life

### DIFF
--- a/lcls_tools/common/devices/yaml/generate.py
+++ b/lcls_tools/common/devices/yaml/generate.py
@@ -2,7 +2,6 @@ import csv
 import yaml
 import os
 from typing import Any, Union, List, Dict, Optional
-import meme.names
 import numpy as np
 from lcls_tools.common.devices.yaml.metadata import (
     get_magnet_metadata,
@@ -153,6 +152,8 @@ class YAMLGenerator:
     def _construct_pv_list_from_control_system_name(
         self, name, search_with_handles: Optional[Dict[str, str]]
     ) -> Dict[str, str]:
+        import meme.names
+
         if name == "":
             raise RuntimeError("No control system name provided for meme search.")
         # Use the control system name to get all PVs associated with device

--- a/lcls_tools/common/devices/yaml/generate.py
+++ b/lcls_tools/common/devices/yaml/generate.py
@@ -228,6 +228,7 @@ class YAMLGenerator:
         for device in device_elements:
             # We need a control-system-name
             if device["Control System Name"] != "":
+                pv_info = None
                 try:
                     # grab the pv information for this element using the search_list
                     pv_info = self._construct_pv_list_from_control_system_name(

--- a/lcls_tools/common/devices/yaml/write.py
+++ b/lcls_tools/common/devices/yaml/write.py
@@ -15,13 +15,15 @@ class YAMLWriter:
     def _is_area(self, area: str) -> bool:
         return area in self.generator.areas
 
-    def _construct_yaml_contents(self, area: str, device_types: List[str] = None) -> Dict[str, str]:
+    def _construct_yaml_contents(
+        self, area: str, device_types: List[str] = None
+    ) -> Dict[str, str]:
         if device_types is None:
-            device_types = ['magnets', 'screens', 'wires', 'lblms', 'bpms', 'tcavs']
+            device_types = ["magnets", "screens", "wires", "lblms", "bpms", "tcavs"]
 
         file_contents = {}
 
-        if 'magnets' in device_types:
+        if "magnets" in device_types:
             # Generate Magnet content
             magnets = self.generator.extract_magnets(
                 area=area,
@@ -29,7 +31,7 @@ class YAMLWriter:
             if magnets:
                 file_contents["magnets"] = magnets
 
-        if 'screens' in device_types:
+        if "screens" in device_types:
             # Generate Screens content
             screens = self.generator.extract_screens(
                 area=area,
@@ -37,7 +39,7 @@ class YAMLWriter:
             if screens:
                 file_contents["screens"] = screens
 
-        if 'wires' in device_types:
+        if "wires" in device_types:
             # Generate Wire content
             wires = self.generator.extract_wires(
                 area=area,
@@ -45,7 +47,7 @@ class YAMLWriter:
             if wires:
                 file_contents["wires"] = wires
 
-        if 'lblms' in device_types:
+        if "lblms" in device_types:
             # Generate LBLM content
             lblms = self.generator.extract_lblms(
                 area=area,
@@ -53,7 +55,7 @@ class YAMLWriter:
             if lblms:
                 file_contents["lblms"] = lblms
 
-        if 'bpms' in device_types:
+        if "bpms" in device_types:
             # Generate BPM content
             bpms = self.generator.extract_bpms(
                 area=area,
@@ -61,7 +63,7 @@ class YAMLWriter:
             if bpms:
                 file_contents["bpms"] = bpms
 
-        if 'tcavs' in device_types:
+        if "tcavs" in device_types:
             # Generate BPM content
             tcavs = self.generator.extract_tcavs(
                 area=area,
@@ -73,7 +75,7 @@ class YAMLWriter:
             return file_contents
         return None
 
-    def write_yaml_file(self, area: Optional[str] = "GUNB", device_types = None) -> None:
+    def write_yaml_file(self, area: Optional[str] = "GUNB", device_types=None) -> None:
         if area not in self.generator.areas:
             raise RuntimeError(
                 f"Area {area} provided is not a known machine area.",
@@ -86,6 +88,7 @@ class YAMLWriter:
             with open(fullpath, "w") as file:
                 yaml.safe_dump(yaml_output, file)
 
+
 def write(device_types: List[str] = None):
     writer = YAMLWriter()
     areas = writer.areas
@@ -94,4 +97,3 @@ def write(device_types: List[str] = None):
 
 if __name__ == "__main__":
     write()
-    

--- a/lcls_tools/common/devices/yaml/write.py
+++ b/lcls_tools/common/devices/yaml/write.py
@@ -15,56 +15,65 @@ class YAMLWriter:
     def _is_area(self, area: str) -> bool:
         return area in self.generator.areas
 
-    def _constuct_yaml_contents(self, area: str) -> Dict[str, str]:
+    def _construct_yaml_contents(self, area: str, device_types: List[str] = None) -> Dict[str, str]:
+        if device_types is None:
+            device_types = ['magnets', 'screens', 'wires', 'lblms', 'bpms', 'tcavs']
+
         file_contents = {}
 
-        # Generate Magnet content
-        magnets = self.generator.extract_magnets(
-            area=area,
-        )
-        if magnets:
-            file_contents["magnets"] = magnets
+        if 'magnets' in device_types:
+            # Generate Magnet content
+            magnets = self.generator.extract_magnets(
+                area=area,
+            )
+            if magnets:
+                file_contents["magnets"] = magnets
 
-        # Generate Screens content
-        screens = self.generator.extract_screens(
-            area=area,
-        )
-        if screens:
-            file_contents["screens"] = screens
+        if 'screens' in device_types:
+            # Generate Screens content
+            screens = self.generator.extract_screens(
+                area=area,
+            )
+            if screens:
+                file_contents["screens"] = screens
 
-        # Generate Wire content
-        wires = self.generator.extract_wires(
-            area=area,
-        )
-        if wires:
-            file_contents["wires"] = wires
+        if 'wires' in device_types:
+            # Generate Wire content
+            wires = self.generator.extract_wires(
+                area=area,
+            )
+            if wires:
+                file_contents["wires"] = wires
 
-        # Generate LBLM content
-        lblms = self.generator.extract_lblms(
-            area=area,
-        )
-        if lblms:
-            file_contents["lblms"] = lblms
+        if 'lblms' in device_types:
+            # Generate LBLM content
+            lblms = self.generator.extract_lblms(
+                area=area,
+            )
+            if lblms:
+                file_contents["lblms"] = lblms
 
-        # Generate BPM content
-        bpms = self.generator.extract_bpms(
-            area=area,
-        )
-        if bpms:
-            file_contents["bpms"] = bpms
+        if 'bpms' in device_types:
+            # Generate BPM content
+            bpms = self.generator.extract_bpms(
+                area=area,
+            )
+            if bpms:
+                file_contents["bpms"] = bpms
 
-        # Generate BPM content
-        tcavs = self.generator.extract_tcavs(
-            area=area,
-        )
-        if tcavs and area == "DIAG0":
-            file_contents["tcavs"] = tcavs
+        if 'tcavs' in device_types:
+            # Generate BPM content
+            tcavs = self.generator.extract_tcavs(
+                area=area,
+            )
+            if tcavs and area == "DIAG0":
+                file_contents["tcavs"] = tcavs
 
         if file_contents:
             return file_contents
         return None
 
-    def write_yaml_file(self, area: Optional[str] = "GUNB") -> None:
+    def write_yaml_file(self, area: Optional[str] = "GUNB", device_types = None) -> None:
         if area not in self.generator.areas:
             raise RuntimeError(
                 f"Area {area} provided is not a known machine area.",
@@ -72,13 +81,17 @@ class YAMLWriter:
         filename = area + ".yaml"
         location = "lcls_tools/common/devices/yaml/"
         fullpath = os.path.join(location, filename)
-        yaml_output = self._constuct_yaml_contents(area=area)
+        yaml_output = self._constuct_yaml_contents(area=area, device_types=device_types)
         if yaml_output:
             with open(fullpath, "w") as file:
                 yaml.safe_dump(yaml_output, file)
 
-
-if __name__ == "__main__":
+def write(device_types: List[str] = None):
     writer = YAMLWriter()
     areas = writer.areas
     [writer.write_yaml_file(area) for area in areas]
+
+
+if __name__ == "__main__":
+    write()
+    

--- a/lcls_tools/common/devices/yaml/write.py
+++ b/lcls_tools/common/devices/yaml/write.py
@@ -83,7 +83,9 @@ class YAMLWriter:
         filename = area + ".yaml"
         location = "lcls_tools/common/devices/yaml/"
         fullpath = os.path.join(location, filename)
-        yaml_output = self._constuct_yaml_contents(area=area, device_types=device_types)
+        yaml_output = self._construct_yaml_contents(
+            area=area, device_types=device_types
+        )
         if yaml_output:
             with open(fullpath, "w") as file:
                 yaml.safe_dump(yaml_output, file)

--- a/lcls_tools/common/devices/yaml/write.py
+++ b/lcls_tools/common/devices/yaml/write.py
@@ -94,7 +94,7 @@ class YAMLWriter:
 def write(device_types: List[str] = None):
     writer = YAMLWriter()
     areas = writer.areas
-    [writer.write_yaml_file(area) for area in areas]
+    [writer.write_yaml_file(area, device_types=device_types) for area in areas]
 
 
 if __name__ == "__main__":

--- a/tests/unit_tests/lcls_tools/common/devices/test_write.py
+++ b/tests/unit_tests/lcls_tools/common/devices/test_write.py
@@ -1,20 +1,21 @@
 import unittest
-from unittest.mock import Mock
+from unittest.mock import patch
 
-from lcls_tools.common.devices.yaml.write import YAMLWriter
+import lcls_tools.common.devices.yaml.write
 
 
+@patch("lcls_tools.common.devices.yaml.write.YAMLGenerator")
 class TestWrite(unittest.TestCase):
-    def test_single_device_types(self):
-        writer = YAMLWriter()
-        writer.generator = Mock()
+    def test_single_device_types(self, generator_class):
+        writer = lcls_tools.common.devices.yaml.write.YAMLWriter()
+        generator = writer.generator
         mock_dict = {
-            "magnets": writer.generator.extract_magnets,
-            "screens": writer.generator.extract_screens,
-            "wires": writer.generator.extract_wires,
-            "lblms": writer.generator.extract_lblms,
-            "bpms": writer.generator.extract_bpms,
-            "tcavs": writer.generator.extract_tcavs,
+            "magnets": generator.extract_magnets,
+            "screens": generator.extract_screens,
+            "wires": generator.extract_wires,
+            "lblms": generator.extract_lblms,
+            "bpms": generator.extract_bpms,
+            "tcavs": generator.extract_tcavs,
         }
         area = "None"
         for k, v in mock_dict.items():

--- a/tests/unit_tests/lcls_tools/common/devices/test_write.py
+++ b/tests/unit_tests/lcls_tools/common/devices/test_write.py
@@ -1,22 +1,23 @@
 import unittest
-from unittest.mock import patch, Mock
+from unittest.mock import Mock
 
 from lcls_tools.common.devices.yaml.write import YAMLWriter
 
-class TestWrite(unittest.TestCase):
 
+class TestWrite(unittest.TestCase):
     def test_single_device_types(self):
         writer = YAMLWriter()
         writer.generator = Mock()
-        mock_dict = {'magnets': writer.generator.extract_magnets,
-                     'screens': writer.generator.extract_screens,
-                     'wires': writer.generator.extract_wires,
-                     'lblms': writer.generator.extract_lblms,
-                     'bpms': writer.generator.extract_bpms,
-                     'tcavs': writer.generator.extract_tcavs}
-        area = 'None'
+        mock_dict = {
+            "magnets": writer.generator.extract_magnets,
+            "screens": writer.generator.extract_screens,
+            "wires": writer.generator.extract_wires,
+            "lblms": writer.generator.extract_lblms,
+            "bpms": writer.generator.extract_bpms,
+            "tcavs": writer.generator.extract_tcavs,
+        }
+        area = "None"
         for k, v in mock_dict.items():
             device_types = k
             writer._construct_yaml_contents(area=area, device_types=device_types)
-            assert(v.called)
-
+            assert v.called

--- a/tests/unit_tests/lcls_tools/common/devices/test_write.py
+++ b/tests/unit_tests/lcls_tools/common/devices/test_write.py
@@ -1,0 +1,22 @@
+import unittest
+from unittest.mock import patch, Mock
+
+from lcls_tools.common.devices.yaml.write import YAMLWriter
+
+class TestWrite(unittest.TestCase):
+
+    def test_single_device_types(self):
+        writer = YAMLWriter()
+        writer.generator = Mock()
+        mock_dict = {'magnets': writer.generator.extract_magnets,
+                     'screens': writer.generator.extract_screens,
+                     'wires': writer.generator.extract_wires,
+                     'lblms': writer.generator.extract_lblms,
+                     'bpms': writer.generator.extract_bpms,
+                     'tcavs': writer.generator.extract_tcavs}
+        area = 'None'
+        for k, v in mock_dict.items():
+            device_types = k
+            writer._construct_yaml_contents(area=area, device_types=device_types)
+            assert(v.called)
+


### PR DESCRIPTION
A couple of things about running write.py were bothering me. Here's the fixes for them. I fixed one bug where a variable `pv_info` wouldn't be initialized on failure to connect. `write.py` now allows the user to choose what devices they want to write to.