### PR TITLE
write.py Command Line Interface

### DIFF
--- a/lcls_tools/common/devices/yaml/write.py
+++ b/lcls_tools/common/devices/yaml/write.py
@@ -97,10 +97,25 @@ class YAMLWriter:
                 target[k] = v
         return target
 
+    def _lazy_update(self, target, update):
+        for k, v in update.items():
+            if isinstance(v, collections.abc.Mapping):
+                target[k] = self._lazy_update(target.get(k, {}), v)
+            else:
+                if k not in target:
+                    target[k] = v
+        return target
+
     def greedy_write(self, area: Optional[str] = "GUNB") -> None:
         current = self._get_current(area)
         update = self._constuct_yaml_contents(area=area)
         yaml_output = self._greedy_update(current, update)
+        self._yaml_dump(area, yaml_output)
+
+    def lazy_write(self, area: Optional[str] = "GUNB") -> None:
+        current = self._get_current(area)
+        update = self._constuct_yaml_contents(area=area)
+        yaml_output = self._lazy_update(current, update)
         self._yaml_dump(area, yaml_output)
 
 

--- a/lcls_tools/common/devices/yaml/write.py
+++ b/lcls_tools/common/devices/yaml/write.py
@@ -64,13 +64,14 @@ class YAMLWriter:
             return file_contents
         return None
 
-    def write_yaml_file(self, area: Optional[str] = "GUNB") -> None:
+    def write_yaml_file(self, area: Optional[str] = "GUNB", location=None) -> None:
         if area not in self.generator.areas:
             raise RuntimeError(
                 f"Area {area} provided is not a known machine area.",
             )
+        if location is None:
+            location = "lcls_tools/common/devices/yaml/"
         filename = area + ".yaml"
-        location = "lcls_tools/common/devices/yaml/"
         fullpath = os.path.join(location, filename)
         yaml_output = self._constuct_yaml_contents(area=area)
         if yaml_output:
@@ -78,7 +79,12 @@ class YAMLWriter:
                 yaml.safe_dump(yaml_output, file)
 
 
-if __name__ == "__main__":
+def write(location=None):
     writer = YAMLWriter()
     areas = writer.areas
-    [writer.write_yaml_file(area) for area in areas]
+    for area in areas:
+        writer.write_yaml_file(area, location)
+
+
+if __name__ == "__main__":
+    write()

--- a/lcls_tools/common/devices/yaml/write.py
+++ b/lcls_tools/common/devices/yaml/write.py
@@ -20,7 +20,7 @@ class YAMLWriter:
     def _is_area(self, area: str) -> bool:
         return area in self.generator.areas
 
-    def _constuct_yaml_contents(
+    def _construct_yaml_contents(
         self, area: str, devices: List[str] = None
     ) -> Dict[str, str]:
         if area not in self.generator.areas:
@@ -49,7 +49,7 @@ class YAMLWriter:
 
         if file_contents:
             return file_contents
-        return None
+        return {}
 
     def _yaml_dump(self, area, output):
         filename = area + ".yaml"
@@ -58,15 +58,17 @@ class YAMLWriter:
             with open(fullpath, "w") as file:
                 yaml.safe_dump(output, file)
 
+    def overwrite(self, area: Optional[str] = "GUNB") -> None:
+        yaml_output = self._construct_yaml_contents(area=area)
+        self._yaml_dump(area, yaml_output)
+
     def _get_current(self, area):
         area_location = self.out_location + area + ".yaml"
+        if not os.path.exists(area_location):
+            return {}
         with open(area_location, "r") as file:
             res = yaml.safe_load(file)
         return res
-
-    def overwrite(self, area: Optional[str] = "GUNB") -> None:
-        yaml_output = self._constuct_yaml_contents(area=area)
-        self._yaml_dump(area, yaml_output)
 
     def _greedy_update(self, target, update):
         for k, v in update.items():
@@ -75,6 +77,14 @@ class YAMLWriter:
             else:
                 target[k] = v
         return target
+
+    def greedy_write(
+        self, area: Optional[str] = "GUNB", devices: List[str] = None
+    ) -> None:
+        current = self._get_current(area)
+        update = self._construct_yaml_contents(area=area, devices=devices)
+        yaml_output = self._greedy_update(current, update)
+        self._yaml_dump(area, yaml_output)
 
     def _lazy_update(self, target, update):
         for k, v in update.items():
@@ -85,19 +95,11 @@ class YAMLWriter:
                     target[k] = v
         return target
 
-    def greedy_write(
-        self, area: Optional[str] = "GUNB", devices: List[str] = None
-    ) -> None:
-        current = self._get_current(area)
-        update = self._constuct_yaml_contents(area=area, devices=devices)
-        yaml_output = self._greedy_update(current, update)
-        self._yaml_dump(area, yaml_output)
-
     def lazy_write(
         self, area: Optional[str] = "GUNB", devices: List[str] = None
     ) -> None:
         current = self._get_current(area)
-        update = self._constuct_yaml_contents(area=area, devices=devices)
+        update = self._construct_yaml_contents(area=area, devices=devices)
         yaml_output = self._lazy_update(current, update)
         self._yaml_dump(area, yaml_output)
 

--- a/lcls_tools/common/devices/yaml/write.py
+++ b/lcls_tools/common/devices/yaml/write.py
@@ -85,15 +85,19 @@ class YAMLWriter:
                     target[k] = v
         return target
 
-    def greedy_write(self, area: Optional[str] = "GUNB") -> None:
+    def greedy_write(
+        self, area: Optional[str] = "GUNB", devices: List[str] = None
+    ) -> None:
         current = self._get_current(area)
-        update = self._constuct_yaml_contents(area=area)
+        update = self._constuct_yaml_contents(area=area, devices=devices)
         yaml_output = self._greedy_update(current, update)
         self._yaml_dump(area, yaml_output)
 
-    def lazy_write(self, area: Optional[str] = "GUNB") -> None:
+    def lazy_write(
+        self, area: Optional[str] = "GUNB", devices: List[str] = None
+    ) -> None:
         current = self._get_current(area)
-        update = self._constuct_yaml_contents(area=area)
+        update = self._constuct_yaml_contents(area=area, devices=devices)
         yaml_output = self._lazy_update(current, update)
         self._yaml_dump(area, yaml_output)
 
@@ -110,7 +114,7 @@ def write(mode="overwrite", devices=None, areas=None, location=None):
         case "lazy":
             selected_writer = yaml_writer.lazy_write
     for area in areas:
-        selected_writer(area, devices=devices)
+        selected_writer(area)
 
 
 if __name__ == "__main__":

--- a/lcls_tools/common/devices/yaml/write.py
+++ b/lcls_tools/common/devices/yaml/write.py
@@ -132,7 +132,7 @@ if __name__ == "__main__":
         nargs="+",
         help=(
             "The devices to read from lcls_elements.csv. Use this arg "
-            "with --mode greedy or lazy to avoid deleting devices that"
+            "with --mode greedy or lazy to avoid deleting devices that "
             "aren't currently selected."
         ),
     )

--- a/tests/unit_tests/lcls_tools/common/devices/yaml/AREA.yaml
+++ b/tests/unit_tests/lcls_tools/common/devices/yaml/AREA.yaml
@@ -1,6 +1,0 @@
-screens:
-  FAKESCREEN:
-    new_stuff: 1
-wires:
-  FAKEWIRE:
-    new_stuff: 1

--- a/tests/unit_tests/lcls_tools/common/devices/yaml/AREA.yaml
+++ b/tests/unit_tests/lcls_tools/common/devices/yaml/AREA.yaml
@@ -1,0 +1,6 @@
+screens:
+  FAKESCREEN:
+    new_stuff: 1
+wires:
+  FAKEWIRE:
+    new_stuff: 1

--- a/tests/unit_tests/lcls_tools/common/devices/yaml/test_data/AREA.yaml
+++ b/tests/unit_tests/lcls_tools/common/devices/yaml/test_data/AREA.yaml
@@ -1,16 +1,6 @@
 screens:
   FAKESCREEN:
-    controls_information:
-      PVs:
-        image: SCREEN:FAKE:Image
-      control_name: SCREEN:FAKE
-    metadata:
-      area: FAKE
+    foo: 1
 wires:
   FAKEWIRE:
-    controls_information:
-      PVs:
-        motor: WIRE:FAKE:MOTR
-      control_name: WIRE:FAKE
-    metadata:
-      area: FAKE
+    foo: 1

--- a/tests/unit_tests/lcls_tools/common/devices/yaml/test_data/AREA.yaml
+++ b/tests/unit_tests/lcls_tools/common/devices/yaml/test_data/AREA.yaml
@@ -1,0 +1,16 @@
+screens:
+  FAKESCREEN:
+    controls_information:
+      PVs:
+        image: SCREEN:FAKE:Image
+      control_name: SCREEN:FAKE
+    metadata:
+      area: FAKE
+wires:
+  FAKEWIRE:
+    controls_information:
+      PVs:
+        motor: WIRE:FAKE:MOTR
+      control_name: WIRE:FAKE
+    metadata:
+      area: FAKE

--- a/tests/unit_tests/lcls_tools/common/devices/yaml/test_data/PARTIALAREA.yaml
+++ b/tests/unit_tests/lcls_tools/common/devices/yaml/test_data/PARTIALAREA.yaml
@@ -1,6 +1,7 @@
 screens:
   FAKESCREEN:
-    old_stuff: 1
+    foo: 2
+    bar: 1
 magnets:
   FAKEMAGNET:
-    old_stuff: 1
+    foo: 1

--- a/tests/unit_tests/lcls_tools/common/devices/yaml/test_data/PARTIALAREA.yaml
+++ b/tests/unit_tests/lcls_tools/common/devices/yaml/test_data/PARTIALAREA.yaml
@@ -1,0 +1,6 @@
+screens:
+  FAKESCREEN:
+    old_stuff: 1
+magnets:
+  FAKEMAGNET:
+    old_stuff: 1

--- a/tests/unit_tests/lcls_tools/common/devices/yaml/test_write.py
+++ b/tests/unit_tests/lcls_tools/common/devices/yaml/test_write.py
@@ -1,0 +1,44 @@
+import os
+import unittest
+import lcls_tools.common.devices.yaml.write
+from unittest.mock import patch, PropertyMock
+import yaml
+
+
+class TestWrite(unittest.TestCase):
+    def setUp(self):
+        area_location = (
+            "tests/unit_tests/lcls_tools/common/devices/yaml/test_data/AREA.yaml"
+        )
+        with open(area_location, "r") as file:
+            self.area = yaml.safe_load(file)
+        self.area_location = area_location
+        self.generate_patcher = patch(
+            "lcls_tools.common.devices.yaml.write.YAMLGenerator"
+        )
+        self.mock_generate = self.generate_patcher.start()
+        instance = self.mock_generate.return_value
+        instance.extract_magnets.return_value = {}
+        instance.extract_screens.return_value = self.area["screens"]
+        instance.extract_wires.return_value = self.area["wires"]
+        instance.extract_lblms.return_value = {}
+        instance.extract_bpms.return_value = {}
+        instance.extract_tcavs.return_value = {}
+        type(instance).areas = PropertyMock(return_value=["AREA"])
+        testbed = "tests/unit_tests/lcls_tools/common/devices/yaml/testbed/"
+        if not os.path.exists(testbed):
+            os.makedirs(testbed)
+        self.testbed = testbed
+
+    def tearDown(self):
+        os.system("rm -rf " + self.testbed)
+        self.generate_patcher.stop()
+
+    def test_write_yaml(self):
+        result_location = self.testbed
+        lcls_tools.common.devices.yaml.write.write(location=result_location)
+        result_location += "AREA.yaml"
+        with open(result_location, "r") as file:
+            res = yaml.safe_load(file)
+        assert self.area == res
+        os.system("rm -rf " + result_location)

--- a/tests/unit_tests/lcls_tools/common/devices/yaml/test_write.py
+++ b/tests/unit_tests/lcls_tools/common/devices/yaml/test_write.py
@@ -58,4 +58,22 @@ class TestWrite(unittest.TestCase):
             res = yaml.safe_load(file)
         self.assertIn("wires", res)
         self.assertIn("magnets", res)
-        self.assertIn("old_stuff", res["screens"]["FAKESCREEN"])
+        self.assertIn("bar", res["screens"]["FAKESCREEN"])
+        self.assertEqual(res["screens"]["FAKESCREEN"]["foo"], 1)
+        os.remove(result_location)
+
+    def test_lazy_write_yaml(self):
+        result_location = self.testbed
+        partial_area = self.data_location + "PARTIALAREA.yaml"
+        shutil.copyfile(partial_area, result_location + "AREA.yaml")
+        lcls_tools.common.devices.yaml.write.write(
+            location=result_location, mode="lazy"
+        )
+        result_location += "AREA.yaml"
+        with open(result_location, "r") as file:
+            res = yaml.safe_load(file)
+        self.assertIn("wires", res)
+        self.assertIn("magnets", res)
+        self.assertIn("bar", res["screens"]["FAKESCREEN"])
+        self.assertEqual(res["screens"]["FAKESCREEN"]["foo"], 2)
+        os.remove(result_location)


### PR DESCRIPTION
I wrote this PR because I was annoyed at how `write.py` reads over every device in every single area every single time. The task turned out to be a little bit more complicated than I thought, but I think this is a good solution.

This PR mainly adds two new features, along with a CLI and a few QOL changes.

`write.py` now has three modes. Each mode pulls data from `lcls_elements.csv`, but each one applies that data differently.
- `overwrite` is the default, and works the same as before. The data is treated as a complete source of information, and each YAML file it writes is completely overwritten.
- `greedy` treats the data as a complete update. It adds new fields and devices while overwriting old ones where old fields exist. 
- `lazy` treats the data as a partial update. It only adds new fields and devices, and leaves anything already there alone.

`write.py` also now supports selecting the devices to read and write from. If you use this mode with `overwrite` you will erase the old devices from the YAML files. Only use this feature with the `greedy` or `lazy` write modes.

`python write.py` now supports command line arguments, `--mode` and `--devices`, which should be self explanatory. This PR also adds tests for `write.py`.