### PR TITLE
Update optimize.py

### DIFF
--- a/lcls_tools/common/model/optimize.py
+++ b/lcls_tools/common/model/optimize.py
@@ -97,7 +97,8 @@ def map_fit(curve, x, y, init, bounds=None, prior=None):
               correspond to the params arguments in curve and prior.
         bounds (tuple(tuple[float, float])): Boundaries for the fitted params.
         prior (Callable[params]): The penalty function that biases fitting towards
-              parameter values with high prior likelihood.
+              parameter values with high prior likelihood. If not provided,
+              optimization is reduced to Maximum Likelihood Estimation (MLE).
             params: A list of parameter values scipy.optimize.minimize will fit.
 
     Out:

--- a/lcls_tools/common/model/optimize.py
+++ b/lcls_tools/common/model/optimize.py
@@ -41,13 +41,13 @@ class Parameter(ABC):
 
 def param_fit(curve, params, pos, data, use_prior=False):
     """
-    Given a curve function and parameter objects, computes a 1D curve fit 
+    Given a curve function and parameter objects, computes a 1D curve fit
     using Maximum A Postiori (MAP) fitting.
 
     If `use_prior` is True, prior distributions defined by each parameter will be
-    used to penalize parameter values that have a low prior likelihood. 
+    used to penalize parameter values that have a low prior likelihood.
     If `use_prior` is False, optimization is not weighted by
-    prior parameter distributions, reducing fitting to Maximum Likelihood 
+    prior parameter distributions, reducing fitting to Maximum Likelihood
     Estimation (MLE), commonly referred to as least-squares fitting.
 
     Arguments:
@@ -68,13 +68,16 @@ def param_fit(curve, params, pos, data, use_prior=False):
         return curve(x, *vec)
 
     if use_prior:
-        prior = lambda vec: np.sum([p.prior(v) for v, p in zip(vec, params)])
+
+        def prior(vec):
+            return np.sum([p.prior(v) for v, p in zip(vec, params)])
     else:
         prior = None
 
     bounds = tuple(p.bounds for p in params)
     res = map_fit(forward, x, y, init, bounds, prior)
     return {p.name: p.scale(val, pos, data) for p, val in zip(params, res.x)}
+
 
 def map_fit(curve, x, y, init, bounds=None, prior=None):
     """
@@ -101,6 +104,7 @@ def map_fit(curve, x, y, init, bounds=None, prior=None):
         res: scipy OptimizeResult object.
     """
     if prior is None:
+
         def prior(p):
             return 0
 

--- a/lcls_tools/common/model/optimize.py
+++ b/lcls_tools/common/model/optimize.py
@@ -41,8 +41,14 @@ class Parameter(ABC):
 
 def param_fit(curve, params, pos, data, use_prior=False):
     """
-    Given a curve function and parameter objects, computes a 2D MLE fit on
-    normalized data.
+    Given a curve function and parameter objects, computes a 1D curve fit 
+    using Maximum A Postiori (MAP) fitting.
+
+    If `use_prior` is True, prior distributions defined by each parameter will be
+    used to penalize parameter values that have a low prior likelihood. 
+    If `use_prior` is False, optimization is not weighted by
+    prior parameter distributions, reducing fitting to Maximum Likelihood 
+    Estimation (MLE), commonly referred to as least-squares fitting.
 
     Arguments:
         curve (Callable[x, params]): The curve to be fit.
@@ -52,7 +58,7 @@ def param_fit(curve, params, pos, data, use_prior=False):
               correspond to the params arguments in curve and prior.
         pos (np.array[float]): The data positions.
         data (np.array[float]): The data weights.
-        use_prior (bool): Flag to apply the prior penalty in MLE fit.
+        use_prior (bool): Flag to apply the prior penalty in MAP fit.
     """
     x = (pos - np.min(pos)) / (np.max(pos) - np.min(pos))
     y = (data - np.min(data)) / (np.max(data) - np.min(data))
@@ -61,24 +67,25 @@ def param_fit(curve, params, pos, data, use_prior=False):
     def forward(x, vec):
         return curve(x, *vec)
 
-    def prior(vec):
-        return np.sum([p.prior(v, i) for p, v, i in zip(params, vec, init)])
+    if use_prior:
+        prior = lambda vec: np.sum([p.prior(v) for v, p in zip(vec, params)])
+    else:
+        prior = None
 
     bounds = tuple(p.bounds for p in params)
-    res = max_likelihood(forward, prior, x, y, init, bounds, use_prior)
+    res = map_fit(forward, x, y, init, bounds, prior)
     return {p.name: p.scale(val, pos, data) for p, val in zip(params, res.x)}
 
-
-def max_likelihood(curve, prior, x, y, init, bounds=None, use_prior=False):
+def map_fit(curve, x, y, init, bounds=None, prior=None):
     """
-    Computes a 2D curve fit using Maximum Likelihood Estimation (MLE).
+    Computes a 1D curve fit using Maximum A Postiori (MAP) fitting. If `prior`
+    is None this function assumes a uniform prior distribution for all
+    parameters, equivelent to Maximum Likelihood Estimation (least-squares).
+    If given, the `prior` callable adds a penalty term to optimization that
+    encourages the fit to match the maximum prior likelihood of each parameter.
 
     Arguments:
         curve (Callable[x, params]): The curve to be fit.
-            x: The data positions.
-            params: A list of parameters scipy.optimize.minimize will fit.
-        prior (Callable[params]): The penalty function that encourages
-              the fit to closely match the initial parameter estimation.
             x: The data positions.
             params: A list of parameters scipy.optimize.minimize will fit.
         x (np.array[float]): The data positions.
@@ -86,13 +93,14 @@ def max_likelihood(curve, prior, x, y, init, bounds=None, use_prior=False):
         init (list[float]): The initial parameter estimation. Indicies
               correspond to the params arguments in curve and prior.
         bounds (tuple(tuple[float, float])): Boundaries for the fitted params.
-        use_prior (bool): Flag to apply the prior penalty.
+        prior (Callable[params]): The penalty function that biases fitting towards
+              parameter values with high prior likelihood.
+            params: A list of parameter values scipy.optimize.minimize will fit.
 
     Out:
         res: scipy OptimizeResult object.
     """
-    if not use_prior:
-
+    if prior is None:
         def prior(p):
             return 0
 
@@ -106,6 +114,5 @@ def max_likelihood(curve, prior, x, y, init, bounds=None, use_prior=False):
         init,
         args=(x, y),
         bounds=bounds,
-        method="Powell",
     )
     return res


### PR DESCRIPTION
Refactored `maximum_likelihood` function into `map_fit` function which optionally takes a prior callable object instead of requiring it (removes use_prior flag). Updates `curve_fit` method to use new function + call structure. Updates docstrings for both functions and fixes minor errors with defining / calling prior functions. Removes default use of "Powell" in `scipy.optimize.minimize`