### PR TITLE
Add joint max bmag mode and add interpolation for all bmag modes.

### DIFF
--- a/lcls_tools/common/measurements/emittance_measurement.py
+++ b/lcls_tools/common/measurements/emittance_measurement.py
@@ -122,7 +122,7 @@ class EmittanceMeasurementResult(lcls_tools.common.BaseModel):
         if mode == BMAGMode.GEOMETRIC_MEAN:
             # multiply x and y bmag values to get geometric mean
             bmag = np.sqrt(fits[0] * fits[1])
-        if mode == BMAGMode.JOINT_MAX:
+        elif mode == BMAGMode.JOINT_MAX:
             # get the joint max of the bmag values
             bmag = np.max(fits, axis=0)
         else:

--- a/lcls_tools/common/measurements/emittance_measurement.py
+++ b/lcls_tools/common/measurements/emittance_measurement.py
@@ -1,4 +1,3 @@
-import sys
 import time
 import enum
 from typing import Any, List, Optional

--- a/lcls_tools/common/measurements/emittance_measurement.py
+++ b/lcls_tools/common/measurements/emittance_measurement.py
@@ -28,7 +28,8 @@ class BMAGMode(enum.IntEnum):
     X = 0
     Y = 1
     # Value is not a valid index unlike X & Y
-    GEOMETRIC_MEAN = -sys.maxsize
+    GEOMETRIC_MEAN = -10
+    JOINT_MAX = -11
 
     @classmethod
     def from_any(cls, value):
@@ -90,10 +91,11 @@ class EmittanceMeasurementResult(lcls_tools.common.BaseModel):
         ----------
         mode : str, optional
             The mode to get the best BMAG value for, default is "geometric_mean".
-            Mode can be one of the following: "x", "y", "geometric_mean".
+            Mode can be one of the following: "x", "y", "geometric_mean", "joint_max".
             - "x": get the best BMAG value for the x plane.
             - "y": get the best BMAG value for the y plane.
             - "geometric_mean": get the best BMAG value for the geometric mean of the x and y planes.
+            - "joint_max": get the best BMAG value for the joint max of the x and y planes.
 
         Returns
         -------
@@ -107,29 +109,30 @@ class EmittanceMeasurementResult(lcls_tools.common.BaseModel):
         mode = BMAGMode.from_any(mode)
 
         bmag = self.bmag
+
+        # interpolate between samples
+        fits = []
+
+        min_k = min([min(k) for k in self.quadrupole_pv_values])
+        max_k = max([max(k) for k in self.quadrupole_pv_values])
+        k = np.linspace(min_k, max_k, 100)
+        for i in range(2):
+            bmag_fit = np.polyfit(self.quadrupole_pv_values[i], bmag[i], 2)
+            fits.append(np.polyval(bmag_fit, k))
+
         if mode == BMAGMode.GEOMETRIC_MEAN:
-            # if calculating the geometric mean, we need to interpolate between samples
-            fits = []
-
-            min_k = min([min(k) for k in self.quadrupole_pv_values])
-            max_k = max([max(k) for k in self.quadrupole_pv_values])
-            k = np.linspace(min_k, max_k, 100)
-            for i in range(2):
-                bmag_fit = np.polyfit(self.quadrupole_pv_values[i], bmag[i], 2)
-                fits.append(np.polyval(bmag_fit, k))
-
             # multiply x and y bmag values to get geometric mean
             bmag = np.sqrt(fits[0] * fits[1])
-
-            # get best index and return bmag value and corresponding pv value
-            best_index = np.argmin(bmag)
-            bmag_value = bmag[best_index]
-            best_pv_value = k[best_index]
-
+        if mode == BMAGMode.JOINT_MAX:
+            # get the joint max of the bmag values
+            bmag = np.max(fits, axis=0)
         else:
-            best_index = np.argmin(bmag[mode.value])
-            bmag_value = bmag[mode.value][best_index]
-            best_pv_value = self.quadrupole_pv_values[mode.value][best_index]
+            bmag = fits[mode.value]
+            
+        # get best index and return bmag value and corresponding pv value
+        best_index = np.argmin(bmag)
+        bmag_value = bmag[best_index]
+        best_pv_value = k[best_index]
 
         return bmag_value, best_pv_value
 

--- a/lcls_tools/common/measurements/emittance_measurement.py
+++ b/lcls_tools/common/measurements/emittance_measurement.py
@@ -128,7 +128,7 @@ class EmittanceMeasurementResult(lcls_tools.common.BaseModel):
             bmag = np.max(fits, axis=0)
         else:
             bmag = fits[mode.value]
-            
+
         # get best index and return bmag value and corresponding pv value
         best_index = np.argmin(bmag)
         bmag_value = bmag[best_index]

--- a/tests/unit_tests/lcls_tools/common/measurements/test_emittance_measurement.py
+++ b/tests/unit_tests/lcls_tools/common/measurements/test_emittance_measurement.py
@@ -189,17 +189,20 @@ class EmittanceMeasurementTest(TestCase):
                     assert np.allclose(result.bmag[0][4], 1.0)
 
                     # test get_best_bmag method
-                    for mode in ["x", "y", "geometric_mean"]:
+                    for mode in ["x", "y", "geometric_mean", "joint_max"]:
                         best_bmag = result.get_best_bmag(mode)
                         if mode == "x":
-                            assert np.allclose(best_bmag[0], 1.0)
-                            assert np.allclose(best_bmag[1], k[4])
+                            assert np.allclose(best_bmag[0], 1.0, rtol=1e-2)
+                            assert np.allclose(best_bmag[1], k[4], rtol=1e-2)
                         elif mode == "y":
-                            assert np.allclose(best_bmag[0], 1.0)
-                            assert np.allclose(best_bmag[1], k[4])
+                            assert np.allclose(best_bmag[0], 1.0, rtol=1e-2)
+                            assert np.allclose(best_bmag[1], k[4], rtol=1e-2)
                         elif mode == "geometric_mean":
                             assert np.allclose(best_bmag[0], 1.0, rtol=1e-2)
-                            assert np.allclose(best_bmag[1], k[4])
+                            assert np.allclose(best_bmag[1], k[4], rtol=1e-2)
+                        elif mode == "joint_max":
+                            assert np.allclose(best_bmag[0], 1.0, rtol=1e-2)
+                            assert np.allclose(best_bmag[1], -.909, rtol=1e-2)
 
                 # test visualization
                 fig, ax = plot_quad_scan_result(result)

--- a/tests/unit_tests/lcls_tools/common/measurements/test_emittance_measurement.py
+++ b/tests/unit_tests/lcls_tools/common/measurements/test_emittance_measurement.py
@@ -202,7 +202,7 @@ class EmittanceMeasurementTest(TestCase):
                             assert np.allclose(best_bmag[1], k[4], rtol=1e-2)
                         elif mode == "joint_max":
                             assert np.allclose(best_bmag[0], 1.0, rtol=1e-2)
-                            assert np.allclose(best_bmag[1], -.909, rtol=1e-2)
+                            assert np.allclose(best_bmag[1], -0.909, rtol=1e-2)
 
                 # test visualization
                 fig, ax = plot_quad_scan_result(result)


### PR DESCRIPTION
Add joint max bmag mode. Joint max should be more useful as a constraint for emittance optimization than geometric mean (will allow us to more directly constrain both bmags simultaneously).