### PR TITLE
Add beam rate property to Wire device objects

### DIFF
--- a/lcls_tools/common/devices/wire.py
+++ b/lcls_tools/common/devices/wire.py
@@ -59,6 +59,7 @@ class PlaneModel(BaseModel):
 
 class WirePVSet(PVSet):
     abort_scan: PV
+    beam_rate: PV
     enabled: PV
     homed: PV
     initialize: PV
@@ -151,6 +152,11 @@ class Wire(Device):
     def enabled(self):
         """Returns the enabled state of the wire sacnner"""
         return self.controls_information.PVs.enabled.get()
+
+    @property
+    def beam_rate(self):
+        """Returns current beam rate"""
+        return self.controls_information.PVs.beam_rate.get()
 
     @property
     def homed(self):

--- a/lcls_tools/common/devices/yaml/BYP.yaml
+++ b/lcls_tools/common/devices/yaml/BYP.yaml
@@ -61,7 +61,10 @@ bpms:
       type: BPM
   BPMBP16:
     controls_information:
-      PVs: {}
+      PVs:
+        tmit: BPMS:BPN16:400:TMIT
+        x: BPMS:BPN16:400:X
+        y: BPMS:BPN16:400:Y
       control_name: BPMS:BPN16:400
     metadata:
       area: BYP
@@ -118,10 +121,7 @@ bpms:
       type: BPM
   BPMBP19:
     controls_information:
-      PVs:
-        tmit: BPMS:BPN19:400:TMIT
-        x: BPMS:BPN19:400:X
-        y: BPMS:BPN19:400:Y
+      PVs: {}
       control_name: BPMS:BPN19:400
     metadata:
       area: BYP
@@ -1729,6 +1729,7 @@ wires:
     controls_information:
       PVs:
         abort_scan: WIRE:BPN12:850:MOTR.STOP
+        beam_rate: WIRE:BPN12:850:BEAMRATE
         enabled: WIRE:BPN12:850:MOTR_ENABLED_STS
         homed: WIRE:BPN12:850:MOTR_HOMED_STS
         initialize: WIRE:BPN12:850:MOTR_INIT
@@ -1798,16 +1799,17 @@ wires:
       - BPMS:DOG:355
       - BPMS:DOG:405
       lblms:
-      - LBLM11A_1
-      - LBLM11A_2
-      - LBLM11A_3
-      - TMITLOSS
+      - LBLM11A_1:BYP
+      - LBLM11A_2:BYP
+      - LBLM11A_3:BYP
+      - TMITLOSS:BYP
       sum_l_meters: 1212.849
       type: WIRE
   WSBP3:
     controls_information:
       PVs:
         abort_scan: WIRE:BPN14:850:MOTR.STOP
+        beam_rate: WIRE:BPN14:850:BEAMRATE
         enabled: WIRE:BPN14:850:MOTR_ENABLED_STS
         homed: WIRE:BPN14:850:MOTR_HOMED_STS
         initialize: WIRE:BPN14:850:MOTR_INIT
@@ -1877,16 +1879,17 @@ wires:
       - BPMS:DOG:355
       - BPMS:DOG:405
       lblms:
-      - LBLM11A_1
-      - LBLM11A_2
-      - LBLM11A_3
-      - TMITLOSS
+      - LBLM11A_1:BYP
+      - LBLM11A_2:BYP
+      - LBLM11A_3:BYP
+      - TMITLOSS:BYP
       sum_l_meters: 1416.049
       type: WIRE
   WSBP4:
     controls_information:
       PVs:
         abort_scan: WIRE:BPN16:850:MOTR.STOP
+        beam_rate: WIRE:BPN16:850:BEAMRATE
         enabled: WIRE:BPN16:850:MOTR_ENABLED_STS
         homed: WIRE:BPN16:850:MOTR_HOMED_STS
         initialize: WIRE:BPN16:850:MOTR_INIT
@@ -1956,9 +1959,9 @@ wires:
       - BPMS:DOG:355
       - BPMS:DOG:405
       lblms:
-      - LBLM11A_1
-      - LBLM11A_2
-      - LBLM11A_3
-      - TMITLOSS
+      - LBLM11A_1:BYP
+      - LBLM11A_2:BYP
+      - LBLM11A_3:BYP
+      - TMITLOSS:BYP
       sum_l_meters: 1619.249
       type: WIRE

--- a/lcls_tools/common/devices/yaml/COL1.yaml
+++ b/lcls_tools/common/devices/yaml/COL1.yaml
@@ -81,7 +81,10 @@ bpms:
       type: BPM
   BPMC105:
     controls_information:
-      PVs: {}
+      PVs:
+        tmit: BPMS:COL1:400:TMIT
+        x: BPMS:COL1:400:X
+        y: BPMS:COL1:400:Y
       control_name: BPMS:COL1:400
     metadata:
       area: COL1
@@ -98,7 +101,10 @@ bpms:
       type: BPM
   BPMC106:
     controls_information:
-      PVs: {}
+      PVs:
+        tmit: BPMS:COL1:480:TMIT
+        x: BPMS:COL1:480:X
+        y: BPMS:COL1:480:Y
       control_name: BPMS:COL1:480
     metadata:
       area: COL1
@@ -155,7 +161,10 @@ bpms:
       type: BPM
   BPMC109:
     controls_information:
-      PVs: {}
+      PVs:
+        tmit: BPMS:COL1:720:TMIT
+        x: BPMS:COL1:720:X
+        y: BPMS:COL1:720:Y
       control_name: BPMS:COL1:720
     metadata:
       area: COL1
@@ -172,7 +181,10 @@ bpms:
       type: BPM
   BPMC110:
     controls_information:
-      PVs: {}
+      PVs:
+        tmit: BPMS:COL1:800:TMIT
+        x: BPMS:COL1:800:X
+        y: BPMS:COL1:800:Y
       control_name: BPMS:COL1:800
     metadata:
       area: COL1
@@ -808,6 +820,7 @@ wires:
     controls_information:
       PVs:
         abort_scan: WIRE:COL1:360:MOTR.STOP
+        beam_rate: WIRE:COL1:360:BEAMRATE
         enabled: WIRE:COL1:360:MOTR_ENABLED_STS
         homed: WIRE:COL1:360:MOTR_HOMED_STS
         initialize: WIRE:COL1:360:MOTR_INIT
@@ -863,15 +876,16 @@ wires:
       - BPMS:COL1:280
       - BPMS:COL1:320
       lblms:
-      - LBLM03A
-      - LBLM04A
-      - TMITLOSS
+      - LBLM03A:L1B
+      - LBLM04A:L2B
+      - TMITLOSS:COL1
       sum_l_meters: 154.52
       type: WIRE
   WSC106:
     controls_information:
       PVs:
         abort_scan: WIRE:COL1:520:MOTR.STOP
+        beam_rate: WIRE:COL1:520:BEAMRATE
         enabled: WIRE:COL1:520:MOTR_ENABLED_STS
         homed: WIRE:COL1:520:MOTR_HOMED_STS
         initialize: WIRE:COL1:520:MOTR_INIT
@@ -926,15 +940,16 @@ wires:
       - BPMS:COL1:280
       - BPMS:COL1:320
       lblms:
-      - LBLM03A
-      - LBLM04A
-      - TMITLOSS
+      - LBLM03A:L1B
+      - LBLM04A:L2B
+      - TMITLOSS:COL1
       sum_l_meters: 162.52
       type: WIRE
   WSC108:
     controls_information:
       PVs:
         abort_scan: WIRE:COL1:680:MOTR.STOP
+        beam_rate: WIRE:COL1:680:BEAMRATE
         enabled: WIRE:COL1:680:MOTR_ENABLED_STS
         homed: WIRE:COL1:680:MOTR_HOMED_STS
         initialize: WIRE:COL1:680:MOTR_INIT
@@ -990,15 +1005,16 @@ wires:
       - BPMS:COL1:280
       - BPMS:COL1:320
       lblms:
-      - LBLM03A
-      - LBLM04A
-      - TMITLOSS
+      - LBLM03A:L1B
+      - LBLM04A:L2B
+      - TMITLOSS:COL1
       sum_l_meters: 170.52
       type: WIRE
   WSC110:
     controls_information:
       PVs:
         abort_scan: WIRE:COL1:840:MOTR.STOP
+        beam_rate: WIRE:COL1:840:BEAMRATE
         enabled: WIRE:COL1:840:MOTR_ENABLED_STS
         homed: WIRE:COL1:840:MOTR_HOMED_STS
         initialize: WIRE:COL1:840:MOTR_INIT
@@ -1054,8 +1070,8 @@ wires:
       - BPMS:COL1:280
       - BPMS:COL1:320
       lblms:
-      - LBLM03A
-      - LBLM04A
-      - TMITLOSS
+      - LBLM03A:L1B
+      - LBLM04A:L2B
+      - TMITLOSS:COL1
       sum_l_meters: 178.52
       type: WIRE

--- a/lcls_tools/common/devices/yaml/DOG.yaml
+++ b/lcls_tools/common/devices/yaml/DOG.yaml
@@ -1430,11 +1430,16 @@ screens:
         n_bits: PROF:DOG:195:N_OF_BITS
         n_col: PROF:DOG:195:Image:ArraySize1_RBV
         n_row: PROF:DOG:195:Image:ArraySize0_RBV
+        orient_x: PROF:DOG:195:X_ORIENT
+        orient_y: PROF:DOG:195:Y_ORIENT
         ref_rate: PROF:DOG:195:ArrayRate_RBV
         ref_rate_vme: PROF:DOG:195:FRAME_RATE
         resolution: PROF:DOG:195:RESOLUTION
         sys_type: PROF:DOG:195:SYS_TYPE
       control_name: PROF:DOG:195
+      pv_cache:
+        orient_x: Negative
+        orient_y: Negative
     metadata:
       area: DOG
       beam_path:

--- a/lcls_tools/common/devices/yaml/DOG.yaml
+++ b/lcls_tools/common/devices/yaml/DOG.yaml
@@ -121,7 +121,10 @@ bpms:
       type: BPM
   BPMDOG4:
     controls_information:
-      PVs: {}
+      PVs:
+        tmit: BPMS:DOG:165:TMIT
+        x: BPMS:DOG:165:X
+        y: BPMS:DOG:165:Y
       control_name: BPMS:DOG:165
     metadata:
       area: DOG
@@ -138,7 +141,10 @@ bpms:
       type: BPM
   BPMDOG5:
     controls_information:
-      PVs: {}
+      PVs:
+        tmit: BPMS:DOG:180:TMIT
+        x: BPMS:DOG:180:X
+        y: BPMS:DOG:180:Y
       control_name: BPMS:DOG:180
     metadata:
       area: DOG
@@ -215,7 +221,10 @@ bpms:
       type: BPM
   BPML1P:
     controls_information:
-      PVs: {}
+      PVs:
+        tmit: BPMS:DOG:250:TMIT
+        x: BPMS:DOG:250:X
+        y: BPMS:DOG:250:Y
       control_name: BPMS:DOG:250
     metadata:
       area: DOG
@@ -1421,16 +1430,11 @@ screens:
         n_bits: PROF:DOG:195:N_OF_BITS
         n_col: PROF:DOG:195:Image:ArraySize1_RBV
         n_row: PROF:DOG:195:Image:ArraySize0_RBV
-        orient_x: PROF:DOG:195:X_ORIENT
-        orient_y: PROF:DOG:195:Y_ORIENT
         ref_rate: PROF:DOG:195:ArrayRate_RBV
         ref_rate_vme: PROF:DOG:195:FRAME_RATE
         resolution: PROF:DOG:195:RESOLUTION
         sys_type: PROF:DOG:195:SYS_TYPE
       control_name: PROF:DOG:195
-      pv_cache:
-        orient_x: Negative
-        orient_y: Negative
     metadata:
       area: DOG
       beam_path:
@@ -1449,6 +1453,7 @@ wires:
     controls_information:
       PVs:
         abort_scan: WIRE:DOG:655:MOTR.STOP
+        beam_rate: WIRE:DOG:655:BEAMRATE
         enabled: WIRE:DOG:655:MOTR_ENABLED_STS
         homed: WIRE:DOG:655:MOTR_HOMED_STS
         initialize: WIRE:DOG:655:MOTR_INIT
@@ -1518,9 +1523,9 @@ wires:
       - BPMS:DOG:355
       - BPMS:DOG:405
       lblms:
-      - LBLM11A_1
-      - LBLM11A_2
-      - LBLM11A_3
-      - TMITLOSS
+      - LBLM11A_1:BYP
+      - LBLM11A_2:BYP
+      - LBLM11A_3:BYP
+      - TMITLOSS:BYP
       sum_l_meters: 1009.649
       type: WIRE

--- a/lcls_tools/common/devices/yaml/EMIT2.yaml
+++ b/lcls_tools/common/devices/yaml/EMIT2.yaml
@@ -285,6 +285,7 @@ wires:
     controls_information:
       PVs:
         abort_scan: WIRE:EMIT2:600:MOTR.STOP
+        beam_rate: WIRE:EMIT2:600:BEAMRATE
         enabled: WIRE:EMIT2:600:MOTR_ENABLED_STS
         homed: WIRE:EMIT2:600:MOTR_HOMED_STS
         initialize: WIRE:EMIT2:600:MOTR_INIT
@@ -336,8 +337,8 @@ wires:
       - BPMS:EMIT2:150
       - BPMS:EMIT2:300
       lblms:
-      - LBLM04A
-      - LBLM07A
-      - TMITLOSS
+      - LBLM04A:L2B
+      - LBLM07A:L3B
+      - TMITLOSS:EMIT2
       sum_l_meters: 384.229
       type: WIRE

--- a/lcls_tools/common/devices/yaml/HTR.yaml
+++ b/lcls_tools/common/devices/yaml/HTR.yaml
@@ -972,11 +972,16 @@ screens:
         n_bits: OTRS:HTR:330:N_OF_BITS
         n_col: OTRS:HTR:330:Image:ArraySize1_RBV
         n_row: OTRS:HTR:330:Image:ArraySize0_RBV
+        orient_x: OTRS:HTR:330:X_ORIENT
+        orient_y: OTRS:HTR:330:Y_ORIENT
         ref_rate: OTRS:HTR:330:ArrayRate_RBV
         ref_rate_vme: OTRS:HTR:330:FRAME_RATE
         resolution: OTRS:HTR:330:RESOLUTION
         sys_type: OTRS:HTR:330:SYS_TYPE
       control_name: OTRS:HTR:330
+      pv_cache:
+        orient_x: Negative
+        orient_y: Negative
     metadata:
       area: HTR
       beam_path:
@@ -998,11 +1003,16 @@ screens:
         n_bits: YAGS:HTR:625:N_OF_BITS
         n_col: YAGS:HTR:625:Image:ArraySize1_RBV
         n_row: YAGS:HTR:625:Image:ArraySize0_RBV
+        orient_x: YAGS:HTR:625:X_ORIENT
+        orient_y: YAGS:HTR:625:Y_ORIENT
         ref_rate: YAGS:HTR:625:ArrayRate_RBV
         ref_rate_vme: YAGS:HTR:625:FRAME_RATE
         resolution: YAGS:HTR:625:RESOLUTION
         sys_type: YAGS:HTR:625:SYS_TYPE
       control_name: YAGS:HTR:625
+      pv_cache:
+        orient_x: Negative
+        orient_y: Negative
     metadata:
       area: HTR
       beam_path:
@@ -1024,11 +1034,16 @@ screens:
         n_bits: YAGS:HTR:675:N_OF_BITS
         n_col: YAGS:HTR:675:Image:ArraySize1_RBV
         n_row: YAGS:HTR:675:Image:ArraySize0_RBV
+        orient_x: YAGS:HTR:675:X_ORIENT
+        orient_y: YAGS:HTR:675:Y_ORIENT
         ref_rate: YAGS:HTR:675:ArrayRate_RBV
         ref_rate_vme: YAGS:HTR:675:FRAME_RATE
         resolution: YAGS:HTR:675:RESOLUTION
         sys_type: YAGS:HTR:675:SYS_TYPE
       control_name: YAGS:HTR:675
+      pv_cache:
+        orient_x: Negative
+        orient_y: Negative
     metadata:
       area: HTR
       beam_path:

--- a/lcls_tools/common/devices/yaml/HTR.yaml
+++ b/lcls_tools/common/devices/yaml/HTR.yaml
@@ -190,7 +190,10 @@ bpms:
       type: BPM
   BPMHD04:
     controls_information:
-      PVs: {}
+      PVs:
+        tmit: BPMS:HTR:980:TMIT
+        x: BPMS:HTR:980:X
+        y: BPMS:HTR:980:Y
       control_name: BPMS:HTR:980
     metadata:
       area: HTR
@@ -969,16 +972,11 @@ screens:
         n_bits: OTRS:HTR:330:N_OF_BITS
         n_col: OTRS:HTR:330:Image:ArraySize1_RBV
         n_row: OTRS:HTR:330:Image:ArraySize0_RBV
-        orient_x: OTRS:HTR:330:X_ORIENT
-        orient_y: OTRS:HTR:330:Y_ORIENT
         ref_rate: OTRS:HTR:330:ArrayRate_RBV
         ref_rate_vme: OTRS:HTR:330:FRAME_RATE
         resolution: OTRS:HTR:330:RESOLUTION
         sys_type: OTRS:HTR:330:SYS_TYPE
       control_name: OTRS:HTR:330
-      pv_cache:
-        orient_x: Negative
-        orient_y: Negative
     metadata:
       area: HTR
       beam_path:
@@ -1000,16 +998,11 @@ screens:
         n_bits: YAGS:HTR:625:N_OF_BITS
         n_col: YAGS:HTR:625:Image:ArraySize1_RBV
         n_row: YAGS:HTR:625:Image:ArraySize0_RBV
-        orient_x: YAGS:HTR:625:X_ORIENT
-        orient_y: YAGS:HTR:625:Y_ORIENT
         ref_rate: YAGS:HTR:625:ArrayRate_RBV
         ref_rate_vme: YAGS:HTR:625:FRAME_RATE
         resolution: YAGS:HTR:625:RESOLUTION
         sys_type: YAGS:HTR:625:SYS_TYPE
       control_name: YAGS:HTR:625
-      pv_cache:
-        orient_x: Negative
-        orient_y: Negative
     metadata:
       area: HTR
       beam_path:
@@ -1031,16 +1024,11 @@ screens:
         n_bits: YAGS:HTR:675:N_OF_BITS
         n_col: YAGS:HTR:675:Image:ArraySize1_RBV
         n_row: YAGS:HTR:675:Image:ArraySize0_RBV
-        orient_x: YAGS:HTR:675:X_ORIENT
-        orient_y: YAGS:HTR:675:Y_ORIENT
         ref_rate: YAGS:HTR:675:ArrayRate_RBV
         ref_rate_vme: YAGS:HTR:675:FRAME_RATE
         resolution: YAGS:HTR:675:RESOLUTION
         sys_type: YAGS:HTR:675:SYS_TYPE
       control_name: YAGS:HTR:675
-      pv_cache:
-        orient_x: Negative
-        orient_y: Negative
     metadata:
       area: HTR
       beam_path:
@@ -1060,6 +1048,7 @@ wires:
     controls_information:
       PVs:
         abort_scan: WIRE:HTR:340:MOTR.STOP
+        beam_rate: WIRE:HTR:340:BEAMRATE
         enabled: WIRE:HTR:340:MOTR_ENABLED_STS
         homed: WIRE:HTR:340:MOTR_HOMED_STS
         initialize: WIRE:HTR:340:MOTR_INIT
@@ -1109,7 +1098,7 @@ wires:
       - BPMS:HTR:120
       - BPMS:HTR:320
       lblms:
-      - LBLM01A
-      - LBLM01B
+      - LBLM01A:HTR
+      - LBLM01B:HTR
       sum_l_meters: 24.589
       type: WIRE

--- a/lcls_tools/common/devices/yaml/LTUH.yaml
+++ b/lcls_tools/common/devices/yaml/LTUH.yaml
@@ -2769,16 +2769,11 @@ screens:
         n_bits: YAGS:LTUH:743:N_OF_BITS
         n_col: YAGS:LTUH:743:Image:ArraySize1_RBV
         n_row: YAGS:LTUH:743:Image:ArraySize0_RBV
-        orient_x: YAGS:LTUH:743:X_ORIENT
-        orient_y: YAGS:LTUH:743:Y_ORIENT
         ref_rate: YAGS:LTUH:743:ArrayRate_RBV
         ref_rate_vme: YAGS:LTUH:743:FRAME_RATE
         resolution: YAGS:LTUH:743:RESOLUTION
         sys_type: YAGS:LTUH:743:SYS_TYPE
       control_name: YAGS:LTUH:743
-      pv_cache:
-        orient_x: Negative
-        orient_y: Negative
     metadata:
       area: LTUH
       beam_path:
@@ -2794,6 +2789,7 @@ wires:
     controls_information:
       PVs:
         abort_scan: WIRE:LTUH:715:MOTR.STOP
+        beam_rate: WIRE:LTUH:715:BEAMRATE
         enabled: WIRE:LTUH:715:MOTR_ENABLED_STS
         homed: WIRE:LTUH:715:MOTR_HOMED_STS
         initialize: WIRE:LTUH:715:MOTR_INIT
@@ -2835,6 +2831,7 @@ wires:
     controls_information:
       PVs:
         abort_scan: WIRE:LTUH:735:MOTR.STOP
+        beam_rate: WIRE:LTUH:735:BEAMRATE
         enabled: WIRE:LTUH:735:MOTR_ENABLED_STS
         homed: WIRE:LTUH:735:MOTR_HOMED_STS
         initialize: WIRE:LTUH:735:MOTR_INIT
@@ -2876,6 +2873,7 @@ wires:
     controls_information:
       PVs:
         abort_scan: WIRE:LTUH:755:MOTR.STOP
+        beam_rate: WIRE:LTUH:755:BEAMRATE
         enabled: WIRE:LTUH:755:MOTR_ENABLED_STS
         homed: WIRE:LTUH:755:MOTR_HOMED_STS
         initialize: WIRE:LTUH:755:MOTR_INIT
@@ -2917,6 +2915,7 @@ wires:
     controls_information:
       PVs:
         abort_scan: WIRE:LTUH:775:MOTR.STOP
+        beam_rate: WIRE:LTUH:775:BEAMRATE
         enabled: WIRE:LTUH:775:MOTR_ENABLED_STS
         homed: WIRE:LTUH:775:MOTR_HOMED_STS
         initialize: WIRE:LTUH:775:MOTR_INIT
@@ -2958,6 +2957,7 @@ wires:
     controls_information:
       PVs:
         abort_scan: WIRE:LTUH:246:MOTR.STOP
+        beam_rate: WIRE:LTUH:246:BEAMRATE
         enabled: WIRE:LTUH:246:MOTR_ENABLED_STS
         homed: WIRE:LTUH:246:MOTR_HOMED_STS
         initialize: WIRE:LTUH:246:MOTR_INIT
@@ -3033,6 +3033,7 @@ wires:
     controls_information:
       PVs:
         abort_scan: WIRE:LTUH:122:MOTR.STOP
+        beam_rate: WIRE:LTUH:122:BEAMRATE
         enabled: WIRE:LTUH:122:MOTR_ENABLED_STS
         homed: WIRE:LTUH:122:MOTR_HOMED_STS
         initialize: WIRE:LTUH:122:MOTR_INIT

--- a/lcls_tools/common/devices/yaml/LTUH.yaml
+++ b/lcls_tools/common/devices/yaml/LTUH.yaml
@@ -2736,6 +2736,7 @@ screens:
     controls_information:
       PVs: {}
       control_name: OTRS:LTU1:449
+      pv_cache: {}
     metadata:
       area: LTUH
       beam_path:
@@ -2752,6 +2753,7 @@ screens:
         ref_rate_vme: OTRS:LTUH:745:FRAME_RATE
         sys_type: OTRS:LTUH:745:SYS_TYPE
       control_name: OTRS:LTUH:745
+      pv_cache: {}
     metadata:
       area: LTUH
       beam_path:
@@ -2769,11 +2771,16 @@ screens:
         n_bits: YAGS:LTUH:743:N_OF_BITS
         n_col: YAGS:LTUH:743:Image:ArraySize1_RBV
         n_row: YAGS:LTUH:743:Image:ArraySize0_RBV
+        orient_x: YAGS:LTUH:743:X_ORIENT
+        orient_y: YAGS:LTUH:743:Y_ORIENT
         ref_rate: YAGS:LTUH:743:ArrayRate_RBV
         ref_rate_vme: YAGS:LTUH:743:FRAME_RATE
         resolution: YAGS:LTUH:743:RESOLUTION
         sys_type: YAGS:LTUH:743:SYS_TYPE
       control_name: YAGS:LTUH:743
+      pv_cache:
+        orient_x: Negative
+        orient_y: Negative
     metadata:
       area: LTUH
       beam_path:

--- a/lcls_tools/common/devices/yaml/LTUS.yaml
+++ b/lcls_tools/common/devices/yaml/LTUS.yaml
@@ -2748,6 +2748,7 @@ screens:
     controls_information:
       PVs: {}
       control_name: YAGS:LTUS:417
+      pv_cache: {}
     metadata:
       area: LTUS
       beam_path:

--- a/lcls_tools/common/devices/yaml/LTUS.yaml
+++ b/lcls_tools/common/devices/yaml/LTUS.yaml
@@ -244,7 +244,10 @@ bpms:
       type: BPM
   BPME31B:
     controls_information:
-      PVs: {}
+      PVs:
+        tmit: BPMS:LTUS:720:TMIT
+        x: BPMS:LTUS:720:X
+        y: BPMS:LTUS:720:Y
       control_name: BPMS:LTUS:720
     metadata:
       area: LTUS
@@ -259,7 +262,10 @@ bpms:
       type: BPM
   BPME32B:
     controls_information:
-      PVs: {}
+      PVs:
+        tmit: BPMS:LTUS:730:TMIT
+        x: BPMS:LTUS:730:X
+        y: BPMS:LTUS:730:Y
       control_name: BPMS:LTUS:730
     metadata:
       area: LTUS
@@ -310,7 +316,10 @@ bpms:
       type: BPM
   BPME35B:
     controls_information:
-      PVs: {}
+      PVs:
+        tmit: BPMS:LTUS:760:TMIT
+        x: BPMS:LTUS:760:X
+        y: BPMS:LTUS:760:Y
       control_name: BPMS:LTUS:760
     metadata:
       area: LTUS
@@ -325,7 +334,10 @@ bpms:
       type: BPM
   BPME36B:
     controls_information:
-      PVs: {}
+      PVs:
+        tmit: BPMS:LTUS:780:TMIT
+        x: BPMS:LTUS:780:X
+        y: BPMS:LTUS:780:Y
       control_name: BPMS:LTUS:780
     metadata:
       area: LTUS
@@ -2752,6 +2764,7 @@ wires:
     controls_information:
       PVs:
         abort_scan: WIRE:LTUS:715:MOTR.STOP
+        beam_rate: WIRE:LTUS:715:BEAMRATE
         enabled: WIRE:LTUS:715:MOTR_ENABLED_STS
         homed: WIRE:LTUS:715:MOTR_HOMED_STS
         initialize: WIRE:LTUS:715:MOTR_INIT
@@ -2809,14 +2822,15 @@ wires:
       - BPMS:SPS:840
       - BPMS:SLTS:150
       lblms:
-      - LBLMS32A
-      - TMITLOSS
+      - LBLMS32A:LTUS
+      - TMITLOSS:LTUS
       sum_l_meters: 3434.508
       type: WIRE
   WS32B:
     controls_information:
       PVs:
         abort_scan: WIRE:LTUS:735:MOTR.STOP
+        beam_rate: WIRE:LTUS:735:BEAMRATE
         enabled: WIRE:LTUS:735:MOTR_ENABLED_STS
         homed: WIRE:LTUS:735:MOTR_HOMED_STS
         initialize: WIRE:LTUS:735:MOTR_INIT
@@ -2874,14 +2888,15 @@ wires:
       - BPMS:SPS:840
       - BPMS:SLTS:150
       lblms:
-      - LBLMS32A
-      - TMITLOSS
+      - LBLMS32A:LTUS
+      - TMITLOSS:LTUS
       sum_l_meters: 3469.772
       type: WIRE
   WS33B:
     controls_information:
       PVs:
         abort_scan: WIRE:LTUS:755:MOTR.STOP
+        beam_rate: WIRE:LTUS:755:BEAMRATE
         enabled: WIRE:LTUS:755:MOTR_ENABLED_STS
         homed: WIRE:LTUS:755:MOTR_HOMED_STS
         initialize: WIRE:LTUS:755:MOTR_INIT
@@ -2939,14 +2954,15 @@ wires:
       - BPMS:SPS:840
       - BPMS:SLTS:150
       lblms:
-      - LBLMS32A
-      - TMITLOSS
+      - LBLMS32A:LTUS
+      - TMITLOSS:LTUS
       sum_l_meters: 3505.035
       type: WIRE
   WS34B:
     controls_information:
       PVs:
         abort_scan: WIRE:LTUS:785:MOTR.STOP
+        beam_rate: WIRE:LTUS:785:BEAMRATE
         enabled: WIRE:LTUS:785:MOTR_ENABLED_STS
         homed: WIRE:LTUS:785:MOTR_HOMED_STS
         initialize: WIRE:LTUS:785:MOTR_INIT
@@ -3004,7 +3020,7 @@ wires:
       - BPMS:SPS:840
       - BPMS:SLTS:150
       lblms:
-      - LBLMS32A
-      - TMITLOSS
+      - LBLMS32A:LTUS
+      - TMITLOSS:LTUS
       sum_l_meters: 3540.299
       type: WIRE

--- a/lcls_tools/common/devices/yaml/SPD.yaml
+++ b/lcls_tools/common/devices/yaml/SPD.yaml
@@ -369,6 +369,7 @@ wires:
     controls_information:
       PVs:
         abort_scan: WIRE:SPD:872:MOTR.STOP
+        beam_rate: WIRE:SPD:872:BEAMRATE
         enabled: WIRE:SPD:872:MOTR_ENABLED_STS
         homed: WIRE:SPD:872:MOTR_HOMED_STS
         initialize: WIRE:SPD:872:MOTR_INIT
@@ -412,6 +413,6 @@ wires:
       - BPMS:SPD:525
       - BPMS:SPD:570
       lblms:
-      - LBLM22A
+      - LBLM22A:SPS
       sum_l_meters: 3024.92
       type: WIRE

--- a/lcls_tools/common/devices/yaml/generate.py
+++ b/lcls_tools/common/devices/yaml/generate.py
@@ -382,13 +382,13 @@ class YAMLGenerator:
         # None implies that we are happen using the PV suffix (lowercase) as the name in yaml
         possible_wire_pvs = {
             "MOTR.STOP": "abort_scan",
+            "BEAMRATE": "beam_rate",
             "MOTR_ENABLED_STS": "enabled",
             "MOTR_HOMED_STS": "homed",
             "MOTR_INIT": "initialize",
             "MOTR_INIT_STS": "initialize_status",
             "MOTR": "motor",
             "MOTR.RBV": "motor_rbv",
-            # "POSN": "position",
             "MOTR_RETRACT": "retract",
             "SCANPULSES": "scan_pulses",
             "MOTR.VELO": "speed",

--- a/tests/unit_tests/lcls_tools/common/devices/test_wire.py
+++ b/tests/unit_tests/lcls_tools/common/devices/test_wire.py
@@ -13,6 +13,7 @@ class WireTest(TestCase):
         # Set up some mocks that are needed for all test-cases.
         self.options_and_getter_function = {
             "MOTR.VELO": None,
+            "BEAMRATE": None,
             "MOTR.VMAX": None,
             "MOTR.VBAS": None,
             "MOTR.RBV": None,
@@ -49,6 +50,7 @@ class WireTest(TestCase):
         ]
         self.options_and_getter_function = {
             "MOTR.STOP": self.wire.abort_scan,
+            "BEAMRATE": self.wire.beam_rate,
             "MOTR_ENABLED_STS": self.wire.enabled,
             "MOTR_HOMED_STS": self.wire.homed,
             "MOTR_INIT": self.wire.initialize,
@@ -102,6 +104,7 @@ class WireTest(TestCase):
         # Assert that magnet has public properties
         for item in [
             "abort_scan",
+            "beam_rate",
             "enabled",
             "homed",
             "initialize",


### PR DESCRIPTION
This PR introduces a new `beam_rate` property to Wire device objects to support upcoming wire scan features that require access to the beam rate information.  Address #295.

**Changes**

- Added `beam_rate` as a property in Wire device class
- Included `beam_rate` as a possible PV for `generate.py` 
- Regenerated YAML files