### PR TITLE
Refactor Wire Scan results classes and standardize naming

### DIFF
--- a/lcls_tools/common/measurements/wire_scan_results.py
+++ b/lcls_tools/common/measurements/wire_scan_results.py
@@ -1,0 +1,72 @@
+from pydantic import SerializeAsAny, BaseModel, ConfigDict
+from lcls_tools.common.measurements.utils import NDArrayAnnotatedType
+from typing import Any, Optional, Dict, Tuple
+from datetime import datetime
+
+
+class DetectorFit(BaseModel):
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+    mean: float
+    sigma: float
+    amplitude: float
+    offset: float
+    curve: NDArrayAnnotatedType
+
+
+class FitResult(BaseModel):
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+    mean: float
+    sigma: float
+    amplitude: float
+    offset: float
+    curve: NDArrayAnnotatedType
+
+
+class MeasurementMetadata(BaseModel):
+    wire_name: str
+    area: str
+    beampath: str
+    detectors: list[str]
+    default_detector: str
+    scan_ranges: Dict[str, Tuple[int, int]]
+    timestamp: datetime
+    notes: Optional[str] = None
+
+
+class DetectorMeasurement(BaseModel):
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+    values: NDArrayAnnotatedType
+    units: str | None = None
+    label: str | None = None
+
+
+class ProfileMeasurement(BaseModel):
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+    positions: NDArrayAnnotatedType
+    detectors: dict[str, DetectorMeasurement]
+    profile_idxs: NDArrayAnnotatedType
+
+
+class WireBeamProfileMeasurementResult(BaseModel):
+    """
+    Stores the results of a wire beam profile measurement.
+
+    Attributes:
+        model_config: Allows use of non-standard types
+                      like NDArrayAnnotatedType.
+        profiles (dict): Dictionary of ProfileMeasurement objects
+                         that contains raw data organized by profile.
+        raw_data (dict): Dictionary of device data as np.ndarrays.
+                         Keys are device names.
+        fit_result (dict): Nested dictionary of fit parameters by detector.
+        rms_sizes (dict): Dictionary of tuples containing (x_rms, y_rms) by
+                          detector.
+        metadata: Various data relevant to the wire scan measurement.
+    """
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+    profiles: Dict[str, ProfileMeasurement]
+    raw_data: Dict[str, Any]
+    fit_result: NDArrayAnnotatedType
+    rms_sizes: Dict[str, tuple[float, float]]
+    metadata: SerializeAsAny[Any]


### PR DESCRIPTION
This PR separates out the wire scan results-related classes into a dedicated module for improved readability.  It also standardizes terminology and variables by replacing all instances of "plane" with "profile" across functions and classes.  Address #297.

Note: No functionality changes are implemented with this PR.

**Changes**

- Moved wire scan result classes into a new file (`wire_scan_results.py`)
- Updated references to use new import paths
- Replaced all "plane" with "profile" for consistency