### PR TITLE
Overwrite Mode Works

### DIFF
--- a/lcls_tools/common/devices/yaml/write.py
+++ b/lcls_tools/common/devices/yaml/write.py
@@ -110,13 +110,11 @@ def write(mode="overwrite", devices=None, areas=None, location=None):
         areas = yaml_writer.areas
     match mode:
         case "overwrite":
-            selected_writer = yaml_writer.overwrite
+            yaml_writer.overwrite(areas)
         case "greedy":
-            selected_writer = yaml_writer.greedy_write
+            yaml_writer.greedy_write(areas, devices)
         case "lazy":
-            selected_writer = yaml_writer.lazy_write
-    for area in areas:
-        selected_writer(area, devices)
+            yaml_writer.lazy_write(areas, devices)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
I recently added a greedy and lazy writer to our YAML generator, but broke the default mode, now called overwrite, in the process. This is a quick three line fix to solve that bug. Thanks to @kabanaty for pointing this out to me.