### PR TITLE
Fixed lower boundary for lcls_tools.common.optimize.gaussian

### DIFF
--- a/lcls_tools/common/model/gaussian.py
+++ b/lcls_tools/common/model/gaussian.py
@@ -67,7 +67,7 @@ class amplitude(optimize.Parameter):
 
 class offset(optimize.Parameter):
     name = "off"
-    bounds = (0, 1)
+    bounds = (-1, 1)
 
     @staticmethod
     def init(pos, data):


### PR DESCRIPTION
The method in lcls_tools.common.optimize.gaussian wasn't working when applied to data with negative offset. Fixed as recommended in this issue: https://github.com/slaclab/lcls-tools/issues/287