### PR TITLE
Add pvAccess support

### DIFF
--- a/lcls_tools/common/data/archiver.py
+++ b/lcls_tools/common/data/archiver.py
@@ -7,7 +7,7 @@ from typing import Dict, List, Optional, Union
 
 import requests
 
-from lcls_tools.common.controls.pyepics.utils import EPICS_INVALID_VAL
+from lcls_tools.common.controls.epics import EPICS_INVALID_VAL
 
 ARCHIVER_URL_FORMATTER = "http://lcls-archapp.slac.stanford.edu/retrieval/data/{SUFFIX}"
 

--- a/lcls_tools/common/data/bmad_modeling/bmad_modeling.py
+++ b/lcls_tools/common/data/bmad_modeling/bmad_modeling.py
@@ -1,7 +1,7 @@
 import numpy as np
 import yaml
 import os
-import epics
+from lcls_tools.common.controls.epics import pv_get_direct
 from datetime import datetime, timedelta
 from lcls_live.datamaps import get_datamaps
 from lcls_live.archiver import lcls_archiver_restore
@@ -174,7 +174,7 @@ def get_element(tao, datum):
 
 def get_live(pvlist):
     """Returns dictionary with PV names as keys and values of PVs"""
-    return dict(zip(pvlist, epics.caget_many(pvlist)))
+    return dict(zip(pvlist, [pv_get_direct(item) for item in pvlist]))
 
 
 def use_klys_when_beam_off(tao_cmds, pvdata, beam_code="1"):

--- a/lcls_tools/common/data/bmad_modeling/outputs/bmad_modeling_outputs.py
+++ b/lcls_tools/common/data/bmad_modeling/outputs/bmad_modeling_outputs.py
@@ -1,5 +1,5 @@
 import matplotlib.pyplot as plt
-import epics
+from lcls_tools.common.controls.epics import pv_get_direct
 from lcls_tools.common.data.bmad_modeling import bmad_modeling as mod
 
 
@@ -90,10 +90,10 @@ def quad_table(tao, pct_lim=1, show_energy=False):
         print("Ele.    Device           BDES    BMOD    Bmad     %")
     for element in quads[1:]:
         device = tao.ele_head(element)["alias"]
-        bmod = epics.caget(device + ":BMOD")
-        bdes = epics.caget(device + ":BDES")
-        eact = epics.caget(device + ":EACT")
-        edes = epics.caget(device + ":EDES")
+        bmod = pv_get_direct(device + ":BMOD")
+        bdes = pv_get_direct(device + ":BDES")
+        eact = pv_get_direct(device + ":EACT")
+        edes = pv_get_direct(device + ":EDES")
         e_tot = tao.ele_gen_attribs(element)["E_TOT"] / 1e9
 
         model_bdes = mod.get_bmad_bdes(tao, element)

--- a/lcls_tools/common/devices/bpm.py
+++ b/lcls_tools/common/devices/bpm.py
@@ -15,7 +15,7 @@ from lcls_tools.common.devices.device import (
     Metadata,
     PVSet,
 )
-from epics import PV
+from lcls_tools.common.controls.epics import PV
 
 EPICS_ERROR_MESSAGE = "Unable to connect to EPICS."
 

--- a/lcls_tools/common/devices/device.py
+++ b/lcls_tools/common/devices/device.py
@@ -1,7 +1,6 @@
 from pydantic import SerializeAsAny, ConfigDict, field_validator
 from typing import List, Union, Callable, Dict, Optional
-from epics import PV
-
+from lcls_tools.common.controls.epics import PV
 import lcls_tools
 
 

--- a/lcls_tools/common/devices/ict.py
+++ b/lcls_tools/common/devices/ict.py
@@ -1,7 +1,7 @@
 from pydantic import field_validator, SerializeAsAny
 
 from lcls_tools.common.devices.device import Device, PVSet, ControlInformation, Metadata
-from epics import PV
+from lcls_tools.common.controls.epics import PV
 
 
 class ICTPVSet(PVSet):
@@ -31,4 +31,4 @@ class ICT(Device):
     metadata: SerializeAsAny[Metadata]
 
     def get_charge(self) -> float:
-        return self.controls_information.PVs.charge_nC.get(as_numpy=True)
+        return self.controls_information.PVs.charge_nC.get()

--- a/lcls_tools/common/devices/lblm.py
+++ b/lcls_tools/common/devices/lblm.py
@@ -18,7 +18,7 @@ from lcls_tools.common.devices.device import (
     Metadata,
     PVSet,
 )
-from epics import PV
+from lcls_tools.common.controls.epics import PV
 
 EPICS_ERROR_MESSAGE = "Unable to connect to EPICS."
 

--- a/lcls_tools/common/devices/screen.py
+++ b/lcls_tools/common/devices/screen.py
@@ -15,7 +15,7 @@ from lcls_tools.common.devices.device import (
     PVSet,
 )
 
-from epics import PV
+from lcls_tools.common.controls.epics import PV
 import h5py
 from pydantic import (
     Field,

--- a/lcls_tools/common/devices/tcav.py
+++ b/lcls_tools/common/devices/tcav.py
@@ -14,7 +14,7 @@ from lcls_tools.common.devices.device import (
     Metadata,
     PVSet,
 )
-from epics import PV
+from lcls_tools.common.controls.epics import PV
 
 
 class TCAVPVSet(PVSet):

--- a/lcls_tools/common/devices/wire.py
+++ b/lcls_tools/common/devices/wire.py
@@ -18,7 +18,7 @@ from lcls_tools.common.devices.device import (
     Metadata,
     PVSet,
 )
-from epics import PV
+from lcls_tools.common.controls.epics import PV
 
 EPICS_ERROR_MESSAGE = "Unable to connect to EPICS."
 

--- a/lcls_tools/superconducting/sc_cavity.py
+++ b/lcls_tools/superconducting/sc_cavity.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from time import sleep
 from typing import Optional, Callable, TYPE_CHECKING
 
-from lcls_tools.common.controls.pyepics.utils import PV, EPICS_INVALID_VAL
+from lcls_tools.common.controls.epics import PV, EPICS_INVALID_VAL
 from lcls_tools.superconducting import sc_linac_utils as utils
 
 if TYPE_CHECKING:

--- a/lcls_tools/superconducting/sc_magnet.py
+++ b/lcls_tools/superconducting/sc_magnet.py
@@ -1,6 +1,6 @@
 from typing import Optional, TYPE_CHECKING
 
-from lcls_tools.common.controls.pyepics.utils import PV
+from lcls_tools.common.controls.epics import PV
 from lcls_tools.superconducting import sc_linac_utils as utils
 
 if TYPE_CHECKING:

--- a/lcls_tools/superconducting/sc_piezo.py
+++ b/lcls_tools/superconducting/sc_piezo.py
@@ -1,7 +1,7 @@
 from time import sleep
 from typing import Optional, TYPE_CHECKING
 
-from lcls_tools.common.controls.pyepics.utils import PV
+from lcls_tools.common.controls.epics import PV
 from lcls_tools.superconducting import sc_linac_utils as utils
 
 if TYPE_CHECKING:

--- a/lcls_tools/superconducting/sc_ssa.py
+++ b/lcls_tools/superconducting/sc_ssa.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from time import sleep
 from typing import Optional, TYPE_CHECKING
 
-from lcls_tools.common.controls.pyepics.utils import PV
+from lcls_tools.common.controls.epics import PV
 from lcls_tools.superconducting import sc_linac_utils as utils
 
 if TYPE_CHECKING:

--- a/lcls_tools/superconducting/sc_stepper.py
+++ b/lcls_tools/superconducting/sc_stepper.py
@@ -4,7 +4,7 @@ from typing import Optional, TYPE_CHECKING
 
 from numpy import sign
 
-from lcls_tools.common.controls.pyepics.utils import PV
+from lcls_tools.common.controls.epics import PV
 from lcls_tools.superconducting import sc_linac_utils as utils
 
 if TYPE_CHECKING:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "scipy",
     "matplotlib",
     "pyepics",
+    "p4p",
     "pyyaml",
     "requests",
     "pydantic",

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ numpy
 scipy
 matplotlib
 pyepics
+p4p
 pyyaml
 requests
 pydantic

--- a/tests/unit_tests/lcls_tools/common/devices/test_device.py
+++ b/tests/unit_tests/lcls_tools/common/devices/test_device.py
@@ -2,12 +2,12 @@ import os
 import unittest
 from unittest.mock import MagicMock, patch
 from pydantic import ValidationError
+from lcls_tools.common.controls.epics import PV
 from lcls_tools.common.devices.device import (
     Device,
     ApplyDeviceCallbackError,
     RemoveDeviceCallbackError,
 )
-from epics import PV
 import yaml
 
 

--- a/tests/unit_tests/lcls_tools/superconducting/test_sc_linac.py
+++ b/tests/unit_tests/lcls_tools/superconducting/test_sc_linac.py
@@ -1,7 +1,7 @@
 from unittest import TestCase
 from unittest.mock import MagicMock
 
-from lcls_tools.common.controls.pyepics.utils import EPICS_NO_ALARM_VAL
+from lcls_tools.common.controls.epics import EPICS_NO_ALARM_VAL
 from lcls_tools.superconducting.sc_linac import Machine, Linac
 from lcls_tools.superconducting.sc_linac_utils import (
     ALL_CRYOMODULES,

--- a/tests/unit_tests/lcls_tools/superconducting/test_sc_ssa.py
+++ b/tests/unit_tests/lcls_tools/superconducting/test_sc_ssa.py
@@ -2,7 +2,7 @@ from random import randint, uniform
 from unittest import TestCase
 from unittest.mock import MagicMock
 
-from lcls_tools.common.controls.pyepics.utils import make_mock_pv
+from lcls_tools.common.controls.epics import make_mock_pv
 from lcls_tools.superconducting.sc_linac import CavityIterator, MACHINE
 from lcls_tools.superconducting.sc_linac_utils import (
     SSA_STATUS_ON_VALUE,


### PR DESCRIPTION
Early pvAccess support. Will fall back to Channel Access if the PV doesn't exist. Most of lcls-tools has not been tested with these changes yet, and I expect some things to break since this wrapper doesn't yet handle all of the parameters that epics PV objects can on the p4p side. These changes work when testing in Badger with the Linac simulation server.