### PR TITLE
Add functions for saving/loading measurement results as h5 files

### DIFF
--- a/lcls_tools/common/io.py
+++ b/lcls_tools/common/io.py
@@ -1,25 +1,64 @@
-from typing import Optional
+import json
 
-from lcls_tools.common.measurements.measurement import Measurement
+import h5py
+import numpy as np
 
 
-class HDF5IO:
-    def __init__(self):
-        pass
+def save_measurement_result(result, filepath: str):
+    """
+    Save a measurement result (e.g. EmittanceMeasurementResult)
+    to a desired filepath (e.g. /path/to/file/my_result.h5)
+    """
+    with h5py.File(filepath, "w") as h5f:
+        for field_name, value in result:
+            # Save single arrays
+            if isinstance(value, np.ndarray):
+                h5f.create_dataset(field_name, data=value)
+            # Save lists of arrays
+            elif isinstance(value, list) and all(
+                isinstance(v, np.ndarray) for v in value
+            ):
+                group = h5f.create_group(field_name)
+                for i, array in enumerate(value):
+                    group.create_dataset(str(i), data=array)
+            # Skip None values
+            elif value is None:
+                continue
+            # Try to save as JSON string, if not just string as is
+            else:
+                try:
+                    h5f.attrs[field_name] = json.dumps(value)
+                except TypeError:
+                    h5f.attrs[field_name] = str(value)
 
-    def write(
-        self,
-        measurement_data: dict,
-        measurement_obj: Measurement,
-        filename: Optional[str] = None,
-    ):
-        """
-        Write data to h5file
-        """
-        raise NotImplementedError
 
-    def read(self, filename: Optional[str] = None):
-        """
-        Read data from h5file
-        """
-        raise NotImplementedError
+def load_measurement_result(filepath: str, result_class: type):
+    """
+    Load a measurement result of some result class (e.g. EmittanceMeasurementResult)
+    from some filepath (e.g. /path/to/file/my_result.h5)
+    """
+    data = {}
+
+    with h5py.File(filepath, "r") as h5f:
+        for key in h5f.keys():
+            item = h5f[key]
+            # Load single arrays
+            if isinstance(item, h5py.Dataset):
+                data[key] = item[()]
+            # Load lists of arrays
+            elif isinstance(item, h5py.Group):
+                arrays = []
+                for subkey in sorted(item.keys(), key=lambda x: int(x)):
+                    arrays.append(item[subkey][()])
+                data[key] = arrays
+
+        for attr_key, attr_val in h5f.attrs.items():
+            if isinstance(attr_val, bytes):  # h5py sometimes stores strings as bytes
+                attr_val = attr_val.decode("utf-8")
+
+            try:
+                data[attr_key] = json.loads(attr_val)
+            except json.JSONDecodeError:
+                data[attr_key] = attr_val
+
+    return result_class(**data)


### PR DESCRIPTION
I imagine a bunch of us basically have something like this written individually, so I thought I'd add them here. These are functions that allow one to save/load a measurement result object (e.g. EmittanceMeasurementResult) as an h5 file. While these were written with measurement result objects in mind, they're actually quite general, so I'm open to modifying them to that effect.

- [ ] Add test for saving/loading