### PR TITLE
move validation and serialization of PV objects to base PVSet

### DIFF
--- a/lcls_tools/common/devices/bpm.py
+++ b/lcls_tools/common/devices/bpm.py
@@ -28,10 +28,6 @@ class BPMPVSet(PVSet):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
 
-    @field_validator("*", mode="before")
-    def validate_pv_fields(cls, v: str) -> PV:
-        return PV(v)
-
 
 # TODO
 class BPMControlInformation(ControlInformation):

--- a/lcls_tools/common/devices/device.py
+++ b/lcls_tools/common/devices/device.py
@@ -14,6 +14,8 @@ class PVSet(lcls_tools.common.BaseModel):
 
     @field_validator("*", mode="before")
     def validate_pv_fields(cls, v: str) -> PV:
+        if v is None:
+            return None
         return PV(v)
 
     @field_serializer("*")

--- a/lcls_tools/common/devices/device.py
+++ b/lcls_tools/common/devices/device.py
@@ -18,6 +18,8 @@ class PVSet(lcls_tools.common.BaseModel):
 
     @field_serializer("*")
     def serialize_pv_fields(self, v: PV, _info) -> str:
+        if v is None:
+            return None
         return v.pvname
 
 

--- a/lcls_tools/common/devices/device.py
+++ b/lcls_tools/common/devices/device.py
@@ -1,4 +1,4 @@
-from pydantic import SerializeAsAny, ConfigDict, field_validator
+from pydantic import SerializeAsAny, ConfigDict, field_validator, field_serializer
 from typing import List, Union, Callable, Dict, Optional
 from epics import PV
 
@@ -11,7 +11,16 @@ class PVSet(lcls_tools.common.BaseModel):
         extra="forbid",
         frozen=True,
     )
-    ...
+
+    @field_validator("*", mode="before")
+    def validate_pv_fields(cls, v: str) -> PV:
+        return PV(v)
+
+    @field_serializer("*")
+    def serialize_pv_fields(self, v: PV, _info) -> str:
+        if v is None:
+            return None
+        return v.pvname
 
 
 class ControlInformation(lcls_tools.common.BaseModel):

--- a/lcls_tools/common/devices/device.py
+++ b/lcls_tools/common/devices/device.py
@@ -14,14 +14,10 @@ class PVSet(lcls_tools.common.BaseModel):
 
     @field_validator("*", mode="before")
     def validate_pv_fields(cls, v: str) -> PV:
-        if v is None:
-            return None
         return PV(v)
 
     @field_serializer("*")
     def serialize_pv_fields(self, v: PV, _info) -> str:
-        if v is None:
-            return None
         return v.pvname
 
 

--- a/lcls_tools/common/devices/device.py
+++ b/lcls_tools/common/devices/device.py
@@ -18,10 +18,8 @@ class PVSet(lcls_tools.common.BaseModel):
             return None
         return PV(v)
 
-    @field_serializer("*")
+    @field_serializer("*", when_used="unless-none")
     def serialize_pv_fields(self, v: PV, _info) -> str:
-        if v is None:
-            return None
         return v.pvname
 
 

--- a/lcls_tools/common/devices/ict.py
+++ b/lcls_tools/common/devices/ict.py
@@ -1,4 +1,4 @@
-from pydantic import field_validator, SerializeAsAny
+from pydantic import SerializeAsAny
 
 from lcls_tools.common.devices.device import Device, PVSet, ControlInformation, Metadata
 from epics import PV

--- a/lcls_tools/common/devices/ict.py
+++ b/lcls_tools/common/devices/ict.py
@@ -16,11 +16,6 @@ class ICTPVSet(PVSet):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
 
-    @field_validator("*", mode="before")
-    def validate_pv_fields(cls, v: str):
-        """Convert each PV string from YAML into a PV object"""
-        return PV(v)
-
 
 class ICTControlInformation(ControlInformation):
     PVs: SerializeAsAny[ICTPVSet]

--- a/lcls_tools/common/devices/lblm.py
+++ b/lcls_tools/common/devices/lblm.py
@@ -44,10 +44,6 @@ class LBLMPVSet(PVSet):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
 
-    @field_validator("*", mode="before")
-    def validate_pv_fields(cls, v: str) -> PV:
-        return PV(v)
-
 
 class LBLMControlInformation(ControlInformation):
     PVs: SerializeAsAny[LBLMPVSet]

--- a/lcls_tools/common/devices/magnet.py
+++ b/lcls_tools/common/devices/magnet.py
@@ -5,7 +5,6 @@ from pydantic import (
     PositiveFloat,
     NonNegativeFloat,
     SerializeAsAny,
-    field_validator,
 )
 from typing import (
     Dict,

--- a/lcls_tools/common/devices/magnet.py
+++ b/lcls_tools/common/devices/magnet.py
@@ -35,8 +35,6 @@ class MagnetPVSet(PVSet):
         super(MagnetPVSet, self).__init__(*args, **kwargs)
 
 
-
-
 class MagnetControlInformation(ControlInformation):
     PVs: SerializeAsAny[MagnetPVSet]
     _ctrl_options: SerializeAsAny[Optional[Dict[str, int]]] = dict()

--- a/lcls_tools/common/devices/magnet.py
+++ b/lcls_tools/common/devices/magnet.py
@@ -35,9 +35,7 @@ class MagnetPVSet(PVSet):
     def __init__(self, *args, **kwargs):
         super(MagnetPVSet, self).__init__(*args, **kwargs)
 
-    @field_validator("*", mode="before")
-    def validate_pv_fields(cls, v: str) -> PV:
-        return PV(v)
+
 
 
 class MagnetControlInformation(ControlInformation):

--- a/lcls_tools/common/devices/pmt.py
+++ b/lcls_tools/common/devices/pmt.py
@@ -24,10 +24,6 @@ class PMTPVSet(PVSet):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
 
-    @field_validator("*", mode="before")
-    def validate_pv_fields(cls, v: str) -> PV:
-        return PV(v)
-
 
 class PMTControlInformation(ControlInformation):
     PVs: SerializeAsAny[PMTPVSet]

--- a/lcls_tools/common/devices/screen.py
+++ b/lcls_tools/common/devices/screen.py
@@ -55,11 +55,6 @@ class ScreenPVSet(PVSet):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
 
-    @field_validator("*", mode="before")
-    def validate_pv_fields(cls, v: str):
-        """Convert each PV string from YAML into a PV object"""
-        return PV(v)
-
 
 class ScreenControlInformation(ControlInformation):
     PVs: SerializeAsAny[ScreenPVSet]

--- a/lcls_tools/common/devices/screen.py
+++ b/lcls_tools/common/devices/screen.py
@@ -20,7 +20,6 @@ import h5py
 from pydantic import (
     Field,
     SerializeAsAny,
-    field_validator,
 )
 import numpy as np
 

--- a/lcls_tools/common/devices/tcav.py
+++ b/lcls_tools/common/devices/tcav.py
@@ -29,10 +29,6 @@ class TCAVPVSet(PVSet):
     amplitude_wocho: PV
     phase_avgnt: PV
 
-    @field_validator("*", mode="before")
-    def validate_pv_fields(cls, v: str) -> PV:
-        return PV(v)
-
 
 class TCAVControlInformation(ControlInformation):
     PVs: SerializeAsAny[TCAVPVSet]

--- a/lcls_tools/common/devices/tcav.py
+++ b/lcls_tools/common/devices/tcav.py
@@ -1,7 +1,6 @@
 from pydantic import (
     NonNegativeFloat,
     SerializeAsAny,
-    field_validator,
 )
 from typing import (
     Dict,

--- a/lcls_tools/common/devices/wire.py
+++ b/lcls_tools/common/devices/wire.py
@@ -90,10 +90,6 @@ class WirePVSet(PVSet):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
 
-    @field_validator("*", mode="before")
-    def validate_pv_fields(cls, v: str) -> PV:
-        return PV(v)
-
 
 class WireControlInformation(ControlInformation):
     PVs: SerializeAsAny[WirePVSet]

--- a/tests/unit_tests/lcls_tools/common/data/test_saver.py
+++ b/tests/unit_tests/lcls_tools/common/data/test_saver.py
@@ -239,7 +239,9 @@ class TestH5Saver(unittest.TestCase):
 
         mask = ~np.isnan(rms_sizes_all)
         assert np.allclose(
-            np.asarray(rms_sizes_all)[mask], loaded_dict["rms_sizes_all"][mask], rtol=1e-5
+            np.asarray(rms_sizes_all)[mask],
+            loaded_dict["rms_sizes_all"][mask],
+            rtol=1e-5,
         )
         mask = ~np.isnan(centroids)
         assert np.allclose(

--- a/tests/unit_tests/lcls_tools/common/data/test_saver.py
+++ b/tests/unit_tests/lcls_tools/common/data/test_saver.py
@@ -208,12 +208,12 @@ class TestH5Saver(unittest.TestCase):
 
         processed_images = [image_processor.auto_process(image) for image in images]
 
-        rms_sizes = []
+        rms_sizes_all = []
         centroids = []
         total_intensities = []
         for image in processed_images:
             fit_result = ImageProjectionFit().fit_image(image)
-            rms_sizes.append(fit_result.rms_size)
+            rms_sizes_all.append(fit_result.rms_size)
             centroids.append(fit_result.centroid)
             total_intensities.append(fit_result.total_intensity)
 
@@ -221,7 +221,7 @@ class TestH5Saver(unittest.TestCase):
         result = ScreenBeamProfileMeasurementResult(
             raw_images=images,
             processed_images=processed_images,
-            rms_sizes=rms_sizes or None,
+            rms_sizes_all=rms_sizes_all or None,
             centroids=centroids or None,
             total_intensities=total_intensities or None,
             metadata={"info": "test"},
@@ -237,9 +237,9 @@ class TestH5Saver(unittest.TestCase):
         assert isinstance(loaded_dict["raw_images"], np.ndarray)
         assert np.allclose(images, loaded_dict["raw_images"], rtol=1e-5)
 
-        mask = ~np.isnan(rms_sizes)
+        mask = ~np.isnan(rms_sizes_all)
         assert np.allclose(
-            np.asarray(rms_sizes)[mask], loaded_dict["rms_sizes"][mask], rtol=1e-5
+            np.asarray(rms_sizes_all)[mask], loaded_dict["rms_sizes_all"][mask], rtol=1e-5
         )
         mask = ~np.isnan(centroids)
         assert np.allclose(

--- a/tests/unit_tests/lcls_tools/common/devices/test_magnet.py
+++ b/tests/unit_tests/lcls_tools/common/devices/test_magnet.py
@@ -8,7 +8,7 @@ import inspect
 
 # Local imports
 from lcls_tools.common.devices.reader import create_magnet
-from lcls_tools.common.devices.magnet import MagnetCollection
+from lcls_tools.common.devices.magnet import MagnetCollection, Magnet
 
 
 class MagnetTest(TestCase):
@@ -602,3 +602,12 @@ class MagnetCollectionTest(TestCase):
         magnet_name = "BAD-MAGNET"
         self.magnet_collection.degauss(magnet_name)
         mock_degauss.assert_not_called()
+
+    def test_serialization(self):
+        magnet = self.magnet_collection.magnets["CQ01B"]
+        info = magnet.model_dump()
+        self.assertEqual(info["controls_information"]["PVs"]["bctrl"], magnet.controls_information.PVs.bctrl.pvname)
+
+        # create magnet from info dict
+        new_magnet = Magnet(**info)
+        self.assertEqual(magnet, new_magnet)

--- a/tests/unit_tests/lcls_tools/common/devices/test_magnet.py
+++ b/tests/unit_tests/lcls_tools/common/devices/test_magnet.py
@@ -606,7 +606,10 @@ class MagnetCollectionTest(TestCase):
     def test_serialization(self):
         magnet = self.magnet_collection.magnets["CQ01B"]
         info = magnet.model_dump()
-        self.assertEqual(info["controls_information"]["PVs"]["bctrl"], magnet.controls_information.PVs.bctrl.pvname)
+        self.assertEqual(
+            info["controls_information"]["PVs"]["bctrl"],
+            magnet.controls_information.PVs.bctrl.pvname,
+        )
 
         # create magnet from info dict
         new_magnet = Magnet(**info)

--- a/tests/unit_tests/lcls_tools/common/devices/test_screen.py
+++ b/tests/unit_tests/lcls_tools/common/devices/test_screen.py
@@ -7,6 +7,8 @@ from lcls_tools.common.devices.reader import create_screen
 import h5py
 import numpy as np
 
+from lcls_tools.common.devices.screen import Screen
+
 
 class TestScreen(unittest.TestCase):
     def setUp(self) -> None:
@@ -102,3 +104,11 @@ class TestScreen(unittest.TestCase):
                     self.assertTrue(
                         np.array_equal(np.zeros(shape=(2000, 2000)), f[dataset])
                     )
+
+    def test_serialization(self):
+        info = self.screen.model_dump()
+        self.assertEqual(info["controls_information"]["PVs"]["image"], self.screen.controls_information.PVs.image.pvname)
+
+        # create screen from info dict
+        new_screen = Screen(**info)
+        self.assertEqual(self.screen, new_screen)

--- a/tests/unit_tests/lcls_tools/common/devices/test_screen.py
+++ b/tests/unit_tests/lcls_tools/common/devices/test_screen.py
@@ -107,7 +107,10 @@ class TestScreen(unittest.TestCase):
 
     def test_serialization(self):
         info = self.screen.model_dump()
-        self.assertEqual(info["controls_information"]["PVs"]["image"], self.screen.controls_information.PVs.image.pvname)
+        self.assertEqual(
+            info["controls_information"]["PVs"]["image"],
+            self.screen.controls_information.PVs.image.pvname,
+        )
 
         # create screen from info dict
         new_screen = Screen(**info)


### PR DESCRIPTION
This pull request refactors the way PV (Process Variable) field validation and serialization are handled for device PVSet classes. The main change is centralizing PV string-to-object conversion and serialization logic in the base `PVSet` class, eliminating duplicated code in each device-specific subclass. This results in cleaner, more maintainable code.

**Core PVSet validation and serialization improvements:**

* Added a `field_validator` to the base `PVSet` class in `device.py` to convert PV strings to `PV` objects for all subclasses, and a `field_serializer` to convert `PV` objects back to strings. This ensures consistent handling of PV fields across all device types.

**Code deduplication and cleanup across device modules:**

* Removed redundant `field_validator` methods from all device-specific `PVSet` subclasses (`BPMPVSet`, `ICTPVSet`, `LBLMPVSet`, `MagnetPVSet`, `PMTPVSet`, `ScreenPVSet`, `TCAVPVSet`, `WirePVSet`), since the logic is now handled in the base class. [[1]](diffhunk://#diff-a0b51b8b22e91b19adb536859d14c3f7f312d1ecf5a298b951e82a5e5e5c30d2L31-L34) [[2]](diffhunk://#diff-9881a64bbeea86670d91c8287292b033401d27c7bceea7ad155690e6a22de444L19-L23) [[3]](diffhunk://#diff-430b5b9b571d9e74bfe6287f8c7bfd74f3d4ee97e2eb6f9016acfd0a06cabc04L47-L50) [[4]](diffhunk://#diff-443ce4965bfca0dd51eaa77b8d03790820b442edcd08b034df67279aa639918eL38-R38) [[5]](diffhunk://#diff-76f6e9af90cfd0d54572696dbbad84781389046f06335fd403c5ef4e7bc9859bL27-L30) [[6]](diffhunk://#diff-cb99364424bfec4fa3b739fc682ce88928c90419f5ba5dcec7f3df4ae13ece53L58-L62) [[7]](diffhunk://#diff-c8c7f0561b29c7165d1e6e206f3cc7fb69642e5f8526e593f674e15738d979b7L32-L35) [[8]](diffhunk://#diff-08b0948a36bc9d6b7568850785e9bfa959f9c24a6746a3bb10bb497b61edf93fL93-L96)